### PR TITLE
ci: adopt the mise / unified-Go-version pattern

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,12 +30,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - name: Setup Mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: go.mod
+          experimental: true
+          install_args: --locked
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
-        with:
-          version: v2.12.2
+        run: mise run lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,33 @@ on:
       - published
 
 jobs:
+  versions:
+    name: Versions
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      go-version: ${{ steps.versions.outputs.go-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          cache: false
+          experimental: true
+          install: false
+
+      - name: Resolve versions
+        id: versions
+        run: echo "go-version=$(mise config get tools.go)" >> "$GITHUB_OUTPUT"
+
   release:
     name: Release
+    needs: versions
     permissions:
       contents: read
       id-token: write
@@ -22,6 +47,7 @@ jobs:
       build-args: |
         VERSION=${{ github.ref_name }}
         REVISION=${{ github.sha }}
+        GO_VERSION=${{ needs.versions.outputs.go-version }}
       meta-images: ghcr.io/${{ github.repository }}
       meta-tags: |
         type=semver,pattern={{version}}
@@ -52,11 +78,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - name: Setup Mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: go.mod
           cache: false
+          experimental: true
+          install_args: --locked
 
       - name: Install UPX
         uses: crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368 # v4.0.0

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -2,4 +2,14 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
   postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths"],
+  packageRules: [
+    {
+      description: "Go Toolchain Group",
+      matchManagers: ["mise", "gomod"],
+      matchDepNames: ["go"],
+      matchFileNames: [".mise/config.toml", "go.mod"],
+      groupName: "Go toolchain",
+      groupSlug: "go-toolchain",
+    },
+  ],
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26-alpine AS build
+ARG GO_VERSION
+FROM golang:${GO_VERSION}-alpine AS build
 ARG VERSION=dev
 ARG REVISION=dev
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-operations/yayamlls
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/goccy/go-yaml v1.19.2


### PR DESCRIPTION
Same change as [flate#576](https://github.com/home-operations/flate/pull/576) — brings `yamlls` onto the shared home-ops Go pattern (konflate, tuppr, kromgo) for **mise in CI** and **a single, unified Go version**.

## Why
`.mise/config.toml` pinned Go `1.26.4` while `go.mod` said `1.26.3` — drifted because the Renovate grouping that keeps them in lockstep was missing. CI also bypassed mise in two jobs (`actions/setup-go`).

## Changes
- **Unify the Go version** — `go.mod` `1.26.3 → 1.26.4` (matches mise, which was already correct, so the mise config is unchanged).
- **Renovate "Go Toolchain Group"** — `.mise/config.toml` + `go.mod` now bump together in one PR and never drift again (Go-only; no `node` here).
- **Dockerfile reads the version from mise** — `ARG GO_VERSION` + `FROM golang:${GO_VERSION}-alpine`, replacing the hardcoded `golang:1.26-alpine`.
- **Workflows on mise, not `setup-go`** — `lint.yaml` → `mise run lint`; `release.yaml` gains a `versions` job (`mise config get tools.go`) feeding `GO_VERSION` to the image build, and GoReleaser installs Go via mise (`cache: false` on the publishing job).

Matches your refinements to #576 (no mise-config comment, lean Renovate rule, bare `cache: false`).

## Testing
`go mod tidy` clean (only the go directive), `go build`/`vet` pass, `mise run lint` → **0 issues**, and lefthook (zizmor + yaml/json formatters) passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
