### PR TITLE
ci: path-filter triggers, add concurrency, cache golangci-lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:
@@ -35,6 +39,13 @@ jobs:
         with:
           experimental: true
           install_args: --locked
+
+      - name: Cache golangci-lint
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml') }}
+          restore-keys: ${{ runner.os }}-golangci-lint-
 
       - name: Run linter
         run: mise run lint

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,6 +8,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,16 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   release:
     types:
       - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded main builds (rolling tag); never interrupt a published release.
+  cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:
   versions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Cancel superseded main builds (rolling tag); never interrupt a published release.
   cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What changed

Mirrors the workflow-efficiency change already merged in **home-operations/kromgo#239**, tailored to this repo's actual workflows.

**Path filters** (`paths-ignore: ["**.md"]`) — skip CI on docs-only changes:
- `tests.yaml` — under `push:` and `pull_request:`
- `lint.yaml` — under `push:` and `pull_request:`
- `release.yaml` — under `push:` only (not `release:`, which has no branch context)

**Concurrency** (added only where missing):
- `release.yaml` — cancels superseded `main` builds; never interrupts a published release (`cancel-in-progress: ${{ github.event_name != 'release' }}`)
- `release-please.yaml` — `cancel-in-progress: false` so release PRs are never cut off

**golangci-lint cache** — `lint.yaml` runs golangci-lint via `mise run lint` (not the self-caching `golangci-lint-action`), so a dedicated `actions/cache` step for `~/.cache/golangci-lint` was added after Setup Mise, keyed on `go.sum` + `.golangci.yml`.

## Skipped (with reason)

- `editors.yaml` — left unchanged. Its `pull_request:` trigger already has a `paths:` allow-list (mutually exclusive with `paths-ignore`, and the allow-list already excludes Markdown); its other trigger is `release:` (no push/PR). It also already has a `concurrency:` block.
- `tests.yaml` / `lint.yaml` concurrency — both already had a `concurrency:` block, so none added.
- `release-please.yaml` triggers — left untouched per the change scope.

## Safety

Pure trigger/concurrency/caching tuning. No job logic changed, no required status checks renamed or removed. zizmor `--offline` reports no new findings on any changed workflow.
