### PR TITLE
ci: use Go-prefixed CI job names

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   test:
-    name: Run on Ubuntu
+    name: Go Tests
     runs-on: ubuntu-24.04
     permissions:
       contents: read


### PR DESCRIPTION
Standardizes CI job display names to the `Go Tests` / `Go Lint` convention used by kromgo/tuppr/konflate (and replaces leftover `Run on Ubuntu` placeholder job names where present).

Cosmetic `name:`-only change — no behavior impact (job keys, steps, triggers, and permissions are untouched).
