### PR TITLE
fix(zed): bump extension version to 0.1.2 and track it in release-please

### DIFF
--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "yayamlls"
 name = "yayamlls"
 description = "YAML language server in Go: schema-driven diagnostics, completion, hover, and Flux rendering."
-version = "0.1.0"
+version = "0.1.2"
 schema_version = 1
 authors = ["home-operations"]
 repository = "https://github.com/home-operations/yayamlls"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,6 +22,11 @@
           "type": "json",
           "path": "editors/claude/.claude-plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "toml",
+          "path": "editors/zed/extension.toml",
+          "jsonpath": "$.version"
         }
       ]
     }


### PR DESCRIPTION
The Zed extension manifest (`editors/zed/extension.toml`) was last bumped to `0.1.0` at release 0.1.0 and was left behind by releases 0.1.1 and 0.1.2, because it wasn't listed in release-please's `extra-files`.

This:
- bumps `editors/zed/extension.toml` to `0.1.2` to match the current release
- adds it to `release-please-config.json` `extra-files` (native `toml` updater on `$.version`) so future releases bump it automatically

Needed so the zed-industries/extensions PR can pin the submodule and declare a matching version.