### PR TITLE
chore: add shellcheckrc and stale/renovate workflows

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Renovate
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .renovaterc.json5
+      - .renovate/**.json5
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ".github"
+          permission-actions: write
+
+      - name: Run Renovate
+        id: dispatch
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          RUN_URL=$(gh workflow run renovate.yaml \
+            --repo "${{ github.repository_owner }}/.github" \
+            --ref main \
+            --field "autodiscoverFilter=${REPO_NAME}")
+          echo "run_id=${RUN_URL##*/}" >> "$GITHUB_OUTPUT"
+
+      - name: Await Renovate Completion
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          RUN_ID: ${{ steps.dispatch.outputs.run_id }}
+        run: |
+          gh run watch \
+            --repo "${{ github.repository_owner }}/.github" \
+            "${RUN_ID}" \
+            --exit-status
+
+      - name: Renovate Output
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          RUN_ID: ${{ steps.dispatch.outputs.run_id }}
+        run: |-
+          gh run view \
+            --repo "${{ github.repository_owner }}/.github" \
+            --log "${RUN_ID}"

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Stale
+
+on:
+  schedule:
+    - cron: 30 1 * * *
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    name: Stale
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: "${{ secrets.BOT_CLIENT_ID }}"
+          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Stale
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        with:
+          repo-token: ${{ steps.app-token.outputs.token }}
+          stale-issue-message: |
+            This issue has been marked as stale due to 60 days of inactivity. Please remove the stale label or leave a comment to keep it open.
+            If no action is taken, it will be automatically closed in 7 days.
+          stale-pr-message: |
+            This pull request has been marked as stale due to 60 days of inactivity. Please remove the stale label or leave a comment to keep it open.
+            If no action is taken, it will be automatically closed in 7 days.
+          close-issue-message: |
+            This issue has been automatically closed after 7 days of inactivity following the stale status.
+          close-pr-message: |
+            This pull request has been automatically closed after 7 days of inactivity following the stale status.
+          stale-issue-label: stale
+          stale-pr-label: stale
+          delete-branch: true

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,5 @@
+disable=SC1091
+disable=SC2086
+disable=SC2090
+disable=SC2148
+disable=SC2155


### PR DESCRIPTION
Brings the repo in line with the org standard config and automation:

- `.shellcheckrc` — the repo has shell scripts but was missing the shared shellcheck config used across the org.
- `.github/workflows/stale.yaml` — standard stale-bot workflow.
- `.github/workflows/renovate.yaml` — self-hosted Renovate runner. The repo already extends `local>home-operations/renovate-config` but had no workflow to run it.

All three are copied from the sibling repos' canonical versions.