### PR TITLE
ci: tidy workflows (drop explanatory comments, collapse single-command run blocks)

### DIFF
--- a/.github/workflows/editors.yaml
+++ b/.github/workflows/editors.yaml
@@ -29,7 +29,7 @@ jobs:
       run:
         working-directory: editors/vscode
     permissions:
-      contents: write # upload the .vsix to the release
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -40,8 +40,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          # Disable caching: this job uploads a release artifact, so a cache
-          # poisoned from a fork PR could influence the published .vsix.
           package-manager-cache: false
 
       - name: Install dependencies
@@ -82,7 +80,5 @@ jobs:
       - name: Add wasm target
         run: rustup target add wasm32-wasip1
 
-      # Zed and Gram compile the extension locally at install time, so there is
-      # no prebuilt .wasm to release; this just verifies the crate still builds.
       - name: Build
         run: cargo build --release --locked --target wasm32-wasip1

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -44,17 +44,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RUN_ID: ${{ steps.dispatch.outputs.run_id }}
-        run: |
-          gh run watch \
-            --repo "${{ github.repository_owner }}/.github" \
-            "${RUN_ID}" \
-            --exit-status
+        run: gh run watch --repo "${{ github.repository_owner }}/.github" "${RUN_ID}" --exit-status
 
       - name: Renovate Output
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RUN_ID: ${{ steps.dispatch.outputs.run_id }}
-        run: |-
-          gh run view \
-            --repo "${{ github.repository_owner }}/.github" \
-            --log "${RUN_ID}"
+        run: gh run view --repo "${{ github.repository_owner }}/.github" --log "${RUN_ID}"


### PR DESCRIPTION
Workflow tidy matching [echo#26](https://github.com/home-operations/echo/pull/26) and the e2e-repo rollout — the **comment/format cleanup only** (no e2e parallelization in this PR).

## Changes
- Removed explanatory/rationale comments from the workflows.
- Collapsed single-command multi-line `run:` blocks to one-liners (multi-command blocks left as block scalars).

Functional comments preserved: `# yaml-language-server:`, `# renovate:`, `# zizmor:`.

## Verification
Adversarially reviewed and independently cross-checked: no functional comments removed, YAML valid, and **no `uses:` / `with:` / `env:` / `permissions:` / trigger / logic changes** — comment + run-formatting only. Committed with the pre-commit hooks running (zizmor "No findings", format-yaml clean).
