### PR TITLE
feat(ci): goreleaser Pro — split/merge release matrix + versioned casks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,9 @@ on:
       - main
     paths-ignore:
       - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
   release:
     types:
       - published
@@ -19,6 +22,7 @@ concurrency:
 jobs:
   versions:
     name: Versions
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -41,8 +45,10 @@ jobs:
         id: versions
         run: echo "go-version=$(mise config get tools.go)" >> "$GITHUB_OUTPUT"
 
+  # Publishes images — never runs for PRs (stronger than a fork gate).
   release:
     name: Release
+    if: ${{ github.event_name != 'pull_request' }}
     needs: versions
     permissions:
       contents: read
@@ -72,13 +78,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-  goreleaser:
-    name: GoReleaser
-    if: ${{ github.event_name == 'release' }}
+  # goreleaser Pro split/merge: one build job per GOOS, each writing a
+  # self-contained dist/<goos> handed to the merge job as an artifact.
+  # Snapshot runs on PRs and main pushes exercise the pipeline (keyless —
+  # fork PRs work) and save the Go caches on main — tag runs can only
+  # restore caches saved on the default branch.
+  goreleaser-split:
+    name: GoReleaser (${{ matrix.goos }})
     runs-on: ubuntu-24.04
     permissions:
-      contents: write
-      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, darwin, windows]
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -98,11 +111,87 @@ jobs:
         with:
           install-only: true
 
+      # Keyed per GOOS: GOCACHE entries differ per target. cache-poisoning
+      # rationale in .github/zizmor.yml.
+      - name: Cache Go build outputs
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: goreleaser-go-${{ matrix.goos }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            goreleaser-go-${{ matrix.goos }}-
+
+      - name: Run GoReleaser (split snapshot)
+        if: ${{ github.event_name != 'release' }}
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser-pro # split/merge + versioned casks are Pro features
+          version: "~> v2"
+          args: release --clean --split --snapshot
+        env:
+          # GGOOS filters targets without leaking into hooks (GOOS would).
+          GGOOS: ${{ matrix.goos }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+      - name: Run GoReleaser (split)
+        if: ${{ github.event_name == 'release' }}
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser-pro # split/merge + versioned casks are Pro features
+          version: "~> v2"
+          args: release --clean --split
+        env:
+          GGOOS: ${{ matrix.goos }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+      - name: Upload partial dist
+        if: ${{ github.event_name == 'release' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist-${{ matrix.goos }}
+          path: dist
+          if-no-files-found: error
+          retention-days: 1
+
+  # Checksums/signing/SBOMs/publish over the combined dist/ — never rebuilds.
+  goreleaser-merge:
+    name: GoReleaser (merge)
+    if: ${{ github.event_name == 'release' }}
+    needs: goreleaser-split
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          cache: false
+          experimental: true
+          install_args: --locked
+
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Download partial dists
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: dist-*
+          path: dist
+          merge-multiple: true
 
       - name: Generate Homebrew Tap Token
         id: tap-token
@@ -114,12 +203,13 @@ jobs:
           repositories: homebrew-tap
           permission-contents: write
 
-      - name: Run GoReleaser
+      - name: Run GoReleaser (merge)
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
-          distribution: goreleaser
+          distribution: goreleaser-pro # split/merge + versioned casks are Pro features
           version: "~> v2"
-          args: release --clean
+          args: continue --merge
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           HOMEBREW_TAP_TOKEN: ${{ steps.tap-token.outputs.token }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/zizmorcore/zizmor/main/docs/schemas/zizmor.schema.json
+rules:
+  # Go cache on the goreleaser split legs: tag runs only restore caches saved
+  # from main, and PRs can't write those (PR cache saves are scoped to the PR).
+  cache-poisoning:
+    ignore:
+      - release.yaml

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 version: 2
 project_name: yayamlls
 
@@ -68,6 +68,11 @@ homebrew_casks:
       - yayamlls
     binaries:
       - yayamlls
+    # Versioned casks: @major.minor is overwritten per patch, @major.minor.patch
+    # accumulates one tap file per release.
+    alternative_names:
+      - "yayamlls@{{ .Major }}.{{ .Minor }}"
+      - "yayamlls@{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
     repository:
       owner: home-operations
       name: homebrew-tap
@@ -86,3 +91,8 @@ homebrew_casks:
 # attaches binaries/sboms/sigs to it.
 release:
   mode: keep-existing
+
+# Parallel per-GOOS release jobs (release.yaml): `release --split` legs +
+# one `continue --merge` job for checksums/signing/SBOMs/publish.
+partial:
+  by: goos


### PR DESCRIPTION
## What

Converts the release to **goreleaser Pro** (org license incoming; `GORELEASER_KEY` org secret is being created):

1. **Split/merge release matrix** (`partial: by: goos`) — the single 8m33s goreleaser job (6m40s of which was five concurrent builds of this 70MB+ dependency graph contending for one 4-core runner) becomes three parallel `release --split` legs (linux/darwin/windows via `GGOOS`, all on ubuntu — CGO is off, nothing needs a native runner) plus a `continue --merge` job that does checksums, cosign, SBOMs, the release upload, and the tap cask over the combined `dist/`. Expected wall clock ≈ 4min. Each leg's output is a self-contained `dist/<goos>` (verified locally), handed over as a workflow artifact; binaries travel inside the leg-made archives, so artifact uploads dropping file modes doesn't affect them.
2. **Versioned casks** (`alternative_names`, Pro) — each release also refreshes a `yayamlls@<major>.<minor>` cask in the tap, so users can pin a minor line while plain `yayamlls` tracks latest.
3. `distribution: goreleaser-pro` + `GORELEASER_KEY` on the split and merge jobs; schema comment → `schema-pro.json`.

4. **PR-time release checks**: the workflow now also triggers on `pull_request` — the split legs run in `--snapshot` mode on every PR (keyless: the license key only gates publishing, so fork PRs get full coverage too), catching config/dep breakage before a release does. The publish-capable jobs (`release` images, `goreleaser-merge`) are gated `github.event_name != 'pull_request'`, which is strictly stronger than a fork gate — no PR of any origin can publish.
5. **Warm Go caches + snapshot splits on main pushes** (the autobrr pattern): each split leg caches `~/.cache/go-build` + `~/go/pkg/mod` keyed per GOOS on `go.sum`, so a release only compiles what changed. The legs also run in `--snapshot` mode on every push to main — that continuously exercises the release pipeline AND is what makes the cache function: caches saved on a tag ref are invisible to the next tag (only default-branch caches are restorable from tags), so main pushes are where the caches releases restore get saved. Poisoning analysis is in the workflow comment (tag runs restore only main-saved caches, PRs can't write those, and the workflow never runs on pull_request) with a justified `zizmor: ignore[cache-poisoning]`.

## Verified

With the goreleaser-pro binary (keyless — the key gates publishing): `goreleaser check` passes, and a real `GGOOS=darwin release --clean --split --snapshot` ran end-to-end locally, confirming split legs work and write only `dist/darwin`. `actionlint` + `zizmor` clean. The first release after merge is the full proof (and needs the org secret in place).

Companion: home-operations/flate#815 (identical change).


