### PR TITLE
docs: credit GoReleaser Pro in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,4 +408,8 @@ mise run lint
 mise run build
 ```
 
+## Releases
+
+Release artifacts (archives, the Homebrew cask, SBOMs, and Cosign signatures) are built and published with [GoReleaser Pro](https://goreleaser.com/pro/). If it's useful to your own projects, consider [sponsoring its author](https://github.com/sponsors/caarlos0).
+
 [flate]: https://github.com/home-operations/flate


### PR DESCRIPTION
Adds a short `## Releases` section crediting [GoReleaser Pro](https://goreleaser.com/pro/) (which builds this repo's release artifacts) and pointing readers to [sponsor its author](https://github.com/sponsors/caarlos0). Part of the org-wide acknowledgment across the repos that use it (kopiur, flate, yayamlls, chaski).