### PR TITLE
fix(lsp): rework folding range logic

### DIFF
--- a/internal/folding/folding.go
+++ b/internal/folding/folding.go
@@ -3,6 +3,7 @@ package folding
 
 import (
 	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/token"
 	"github.com/home-operations/yayamlls/internal/yamlast"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
@@ -16,16 +17,59 @@ func Ranges(parsed *yamlast.Parsed) []protocol.FoldingRange {
 		if doc == nil || doc.Body == nil {
 			continue
 		}
-		ast.Walk(visitorFn(func(n ast.Node) {
-			switch n.(type) {
-			case *ast.DocumentNode, *ast.MappingNode, *ast.SequenceNode:
-				if r, ok := extent(n); ok {
-					out = append(out, r)
-				}
-			}
-		}), doc)
+		walkBody(doc.Body, false, &out)
 	}
 	return out
+}
+
+func walkBody(n ast.Node, parentIsMV bool, out *[]protocol.FoldingRange) {
+	if n == nil {
+		return
+	}
+	switch n := n.(type) {
+	case *ast.MappingNode:
+		if shouldEmitRangeForContainer(n, parentIsMV) {
+			if r, ok := extent(n); ok {
+				*out = append(*out, r)
+			}
+		}
+		for _, v := range n.Values {
+			walkBody(v, false, out)
+		}
+	case *ast.MappingValueNode:
+		if r, ok := extent(n); ok {
+			*out = append(*out, r)
+		}
+		walkBody(n.Key, true, out)
+		walkBody(n.Value, true, out)
+	case *ast.SequenceNode:
+		if shouldEmitRangeForContainer(n, parentIsMV) {
+			if r, ok := extent(n); ok {
+				*out = append(*out, r)
+			}
+		}
+		for _, v := range n.Values {
+			walkBody(v, false, out)
+		}
+	}
+}
+
+// Checks whether a MappingNode or SequenceNode should emit
+// its own folding range. A container should not fold when:
+//   - it's nested under a MappingValueNode (parentIsMV) that already
+//     covers the same lines
+//   - it has only one child entry, which will produce the same range
+func shouldEmitRangeForContainer(n ast.Node, parentIsMV bool) bool {
+	if parentIsMV {
+		return false
+	}
+	switch v := n.(type) {
+	case *ast.MappingNode:
+		return len(v.Values) != 1
+	case *ast.SequenceNode:
+		return len(v.Values) != 1
+	}
+	return false
 }
 
 func extent(n ast.Node) (protocol.FoldingRange, bool) {
@@ -38,6 +82,9 @@ func extent(n ast.Node) (protocol.FoldingRange, bool) {
 		if t := c.GetToken(); t != nil && t.Position != nil && t.Position.Line > maxLine {
 			maxLine = t.Position.Line
 		}
+		if t := endToken(c); t != nil && t.Position != nil && t.Position.Line > maxLine {
+			maxLine = t.Position.Line
+		}
 	}), n)
 	startLine := uint32(startTok.Position.Line - 1)
 	endLine := uint32(maxLine - 1)
@@ -46,6 +93,16 @@ func extent(n ast.Node) (protocol.FoldingRange, bool) {
 	}
 	kind := string(protocol.FoldingRangeKindRegion)
 	return protocol.FoldingRange{StartLine: startLine, EndLine: endLine, Kind: &kind}, true
+}
+
+func endToken(n ast.Node) *token.Token {
+	switch v := n.(type) {
+	case *ast.MappingNode:
+		return v.End
+	case *ast.SequenceNode:
+		return v.End
+	}
+	return nil
 }
 
 type visitorFn func(ast.Node)

--- a/internal/folding/folding_test.go
+++ b/internal/folding/folding_test.go
@@ -1,10 +1,54 @@
 package folding
 
 import (
+	"cmp"
+	"fmt"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/home-operations/yayamlls/internal/yamlast"
+	protocol "github.com/tliron/glsp/protocol_3_16"
 )
+
+func formatRanges(ranges []protocol.FoldingRange) string {
+	var b strings.Builder
+	for i, r := range ranges {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "[L%d-L%d]", r.StartLine, r.EndLine)
+	}
+	return b.String()
+}
+
+func assertRanges(t *testing.T, got, want []protocol.FoldingRange) {
+	t.Helper()
+	slices.SortFunc(got, func(a, b protocol.FoldingRange) int {
+		if c := cmp.Compare(a.StartLine, b.StartLine); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.EndLine, b.EndLine)
+	})
+	if !slices.EqualFunc(got, want, func(a, b protocol.FoldingRange) bool {
+		return a.StartLine == b.StartLine && a.EndLine == b.EndLine
+	}) {
+		t.Errorf("ranges mismatch:\n got: %s\nwant: %s", formatRanges(got), formatRanges(want))
+	}
+}
+
+func TestRanges_MultilineMapping(t *testing.T) {
+	text := `apiVersion: "v1"
+kind: "Namespace"
+metadata:
+  name: "test"
+`
+	got := Ranges(yamlast.Parse([]byte(text)))
+	assertRanges(t, got, []protocol.FoldingRange{
+		{StartLine: 0, EndLine: 3}, // root
+		{StartLine: 2, EndLine: 3}, // "metadata:"
+	})
+}
 
 func TestRanges_MultilineMappingAndSequence(t *testing.T) {
 	text := `spec:
@@ -14,38 +58,98 @@ func TestRanges_MultilineMappingAndSequence(t *testing.T) {
   replicas: 3
 `
 	got := Ranges(yamlast.Parse([]byte(text)))
-	if len(got) == 0 {
-		t.Fatalf("expected at least one folding range, got 0")
-	}
-	covers := func(start, end uint32) bool {
-		for _, r := range got {
-			if r.StartLine == start && r.EndLine >= end {
-				return true
-			}
-		}
-		return false
-	}
-	// Whole spec mapping spans lines 0..4 (0-indexed).
-	if !covers(0, 4) {
-		t.Errorf("expected fold covering top-level spec mapping; got %+v", got)
-	}
-	// containers sequence starts on line 2 (where `- name` lives).
-	if !covers(2, 3) {
-		t.Errorf("expected fold for containers sequence; got %+v", got)
-	}
+	assertRanges(t, got, []protocol.FoldingRange{
+		{StartLine: 0, EndLine: 4}, // root
+		{StartLine: 1, EndLine: 3}, // "containers:"
+		{StartLine: 2, EndLine: 3}, // "- name: web"
+	})
+}
+
+func TestRanges_MultilineFlowMapping(t *testing.T) {
+	text := `{
+  apiVersion: "v1",
+  kind: "Namespace",
+  metadata: {
+    name: "test",
+  },
+}
+`
+	got := Ranges(yamlast.Parse([]byte(text)))
+	assertRanges(t, got, []protocol.FoldingRange{
+		{StartLine: 0, EndLine: 6}, // root
+		{StartLine: 3, EndLine: 5}, // "metadata: {"
+	})
+}
+
+func TestRanges_MultilineFlowMappingNested(t *testing.T) {
+	text := `{
+  apiVersion: "v1",
+  kind: "Test",
+  metadata: {
+    name: "test",
+  },
+  spec: {
+    foobar: {
+    },
+  },
+}
+`
+	got := Ranges(yamlast.Parse([]byte(text)))
+	assertRanges(t, got, []protocol.FoldingRange{
+		{StartLine: 0, EndLine: 10}, // root
+		{StartLine: 3, EndLine: 5},  // "metadata:"
+		{StartLine: 6, EndLine: 9},  // "spec:"
+		{StartLine: 7, EndLine: 8},  // "foobar:"
+	})
+}
+
+func TestRanges_MultilineFlowMappingAndSequence(t *testing.T) {
+	text := `{
+  apiVersion: "kustomize.config.k8s.io/v1beta1",
+  kind: "Kustomization",
+  namespace: "test",
+  resources: [
+    "test1.yaml",
+    "test2.yaml"
+  ],
+}
+`
+	got := Ranges(yamlast.Parse([]byte(text)))
+
+	assertRanges(t, got, []protocol.FoldingRange{
+		{StartLine: 0, EndLine: 8}, // root
+		{StartLine: 4, EndLine: 7}, // "resources: ["
+	})
 }
 
 func TestRanges_NoRangeForSingleLineDoc(t *testing.T) {
 	if got := Ranges(yamlast.Parse([]byte("name: x\n"))); len(got) != 0 {
-		t.Errorf("expected zero ranges for single-line doc, got %+v", got)
+		t.Errorf("expected zero ranges for single-line doc, got %s", formatRanges(got))
 	}
+}
+
+func TestRanges_SequenceWithMappings(t *testing.T) {
+	text := `list:
+  - x: 1
+    y: 2
+  - x: 1
+  - x: 1.1
+    y: 6.3
+    z: 2.0
+`
+	got := Ranges(yamlast.Parse([]byte(text)))
+	assertRanges(t, got, []protocol.FoldingRange{
+		{StartLine: 0, EndLine: 6}, // root
+		{StartLine: 1, EndLine: 2}, // first item
+		{StartLine: 4, EndLine: 6}, // third item
+	})
 }
 
 func TestRanges_EmptyAndCommentOnlyDocs(t *testing.T) {
 	// Empty docs have a nil Body; walking them must not panic.
 	for _, text := range []string{"", "# just a comment\n", "---\n# c\n---\n"} {
 		if got := Ranges(yamlast.Parse([]byte(text))); len(got) != 0 {
-			t.Errorf("expected zero ranges for %q, got %+v", text, got)
+			t.Errorf("expected zero ranges for %q, got %s", text, formatRanges(got))
 		}
 	}
 }


### PR DESCRIPTION
## Overview

Fixes #106

### Test case 1:

Before:

https://github.com/user-attachments/assets/6982dc10-57c1-4160-8464-35ed03bd4a5f

After:

https://github.com/user-attachments/assets/e80da3b6-fcc2-47e8-b688-fcfa28ad41b2


### Test case 2

Before:

https://github.com/user-attachments/assets/9a62a43c-35a4-4077-9b64-dfa43fc08e0a

After:

https://github.com/user-attachments/assets/14ea3e18-2b43-44b8-b353-0c199cde1351

I've included other tests cases in `folding_test.go`

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: assisted by AI during debugging and to understand the codebase while iteratively refining the patch. The tests were written by hand.