### PR TITLE
ci: skip release-please churn and stop cancelling main runs

### DIFF
--- a/.github/workflows/editors.yaml
+++ b/.github/workflows/editors.yaml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,16 +8,18 @@ on:
       - main
     paths-ignore:
       - "**.md"
+      - ".release-please-manifest.json"
   pull_request:
     branches:
       - main
     paths-ignore:
       - "**.md"
+      - ".release-please-manifest.json"
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,16 +8,18 @@ on:
       - main
     paths-ignore:
       - "**.md"
+      - ".release-please-manifest.json"
   pull_request:
     branches:
       - main
     paths-ignore:
       - "**.md"
+      - ".release-please-manifest.json"
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Consolidates the CI concurrency and `paths-ignore` changes from home-operations/miroir#265:

- `concurrency.cancel-in-progress` now only cancels **pull_request** runs, so pushes to `main` are no longer interrupted mid-run.
- `.release-please-manifest.json` added to `paths-ignore`, so release-please's manifest bumps no longer trigger these workflows.
