### PR TITLE
style: indent markdown at 2 to match embedded yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.md]
-indent_size = 4
+indent_size = 2
 trim_trailing_whitespace = false
 
 [*.py]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ lenses — is on by default. Disable it to run as a generic YAML language server
 
 ```yaml
 kubernetes:
-    enabled: false
+  enabled: false
 ```
 
 ## vs. redhat/yaml-language-server
@@ -147,9 +147,9 @@ it via **zed: install dev extension**). Since Zed bundles its own
 
 ```jsonc
 {
-    "languages": {
-        "YAML": { "language_servers": ["yayamlls", "!yaml-language-server"] },
-    },
+  "languages": {
+    "YAML": { "language_servers": ["yayamlls", "!yaml-language-server"] },
+  },
 }
 ```
 
@@ -161,17 +161,17 @@ allowed`), so the settings-only alternative is to override the bundled
 ```jsonc
 // ~/.config/zed/settings.json
 {
-    "lsp": {
-        "yaml-language-server": {
-            "binary": {
-                "ignore_system_version": true,
-                "path": "yayamlls",
-            },
-            "initialization_options": {
-                "catalog": true,
-            },
-        },
+  "lsp": {
+    "yaml-language-server": {
+      "binary": {
+        "ignore_system_version": true,
+        "path": "yayamlls",
+      },
+      "initialization_options": {
+        "catalog": true,
+      },
     },
+  },
 }
 ```
 
@@ -218,14 +218,14 @@ the binary on `$PATH`, then:
 ```jsonc
 // opencode.json
 {
-    "$schema": "https://opencode.ai/config.json",
-    "lsp": {
-        "yaml-ls": { "disabled": true },
-        "yayamlls": {
-            "command": ["yayamlls"],
-            "extensions": [".yaml", ".yml"]
-        }
-    }
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "yaml-ls": { "disabled": true },
+    "yayamlls": {
+      "command": ["yayamlls"],
+      "extensions": [".yaml", ".yml"],
+    },
+  },
 }
 ```
 
@@ -264,10 +264,10 @@ yayamlls --log-file /tmp/yayamlls.log -v 2
 
 ```yaml
 schemas:
-    "https://json.schemastore.org/github-workflow.json":
-        - ".github/workflows/*.yml"
-    "./schemas/local.json":
-        - "k8s/**/*.yaml"
+  "https://json.schemastore.org/github-workflow.json":
+    - ".github/workflows/*.yml"
+  "./schemas/local.json":
+    - "k8s/**/*.yaml"
 
 catalog: true
 catalogUrl: ""
@@ -341,7 +341,7 @@ Same shape works via `initializationOptions` or
 Comments mute diagnostics so the language server stops reporting them:
 
 ```yaml
-age: not-a-number  # yayamlls-disable-line
+age: not-a-number # yayamlls-disable-line
 
 # yayamlls-disable-line
 age: not-a-number

--- a/editors/claude/README.md
+++ b/editors/claude/README.md
@@ -3,15 +3,15 @@
 Connects the `yayamlls` language server to [Claude Code](https://claude.com/claude-code).
 Bundles three components:
 
-| Component | What it does |
-| --------- | ------------ |
-| **LSP server** (`.lsp.json`) | Registers `yayamlls` for live diagnostics, hover, and completion on `.yaml`/`.yml` files. |
-| **Hook** (`hooks/hooks.json`) | Runs `yayamlls validate` after each YAML edit and feeds error-severity diagnostics back to Claude. |
-| **Skill** (`skills/yaml/`) | Documents schema resolution order, `.yayamlls.yaml`, suppressions, and Flux rendering. Invokable as `/yayamlls:yaml`. |
+| Component                     | What it does                                                                                                          |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **LSP server** (`.lsp.json`)  | Registers `yayamlls` for live diagnostics, hover, and completion on `.yaml`/`.yml` files.                             |
+| **Hook** (`hooks/hooks.json`) | Runs `yayamlls validate` after each YAML edit and feeds error-severity diagnostics back to Claude.                    |
+| **Skill** (`skills/yaml/`)    | Documents schema resolution order, `.yayamlls.yaml`, suppressions, and Flux rendering. Invokable as `/yayamlls:yaml`. |
 
 ## Prerequisite: install the binary
 
-A Claude Code LSP/hook plugin configures *how* Claude Code reaches a language
+A Claude Code LSP/hook plugin configures _how_ Claude Code reaches a language
 server — it does **not** ship the binary. Put `yayamlls` on your `$PATH` first:
 
 ```sh

--- a/editors/claude/skills/yaml/SKILL.md
+++ b/editors/claude/skills/yaml/SKILL.md
@@ -43,17 +43,17 @@ Lives at the workspace root and is the lowest-precedence settings layer (the
 editor/plugin can override it). Common keys:
 
 ```yaml
-catalog: true               # use the SchemaStore catalog for well-known files
-catalogUrl: https://...     # custom catalog
-kubernetes:                 # apiVersion+kind detection + Flux rendering
-  enabled: true             #   (on by default; set false for generic YAML)
-schemas:                    # schema URL/path -> the file globs it applies to
+catalog: true # use the SchemaStore catalog for well-known files
+catalogUrl: https://... # custom catalog
+kubernetes: # apiVersion+kind detection + Flux rendering
+  enabled: true #   (on by default; set false for generic YAML)
+schemas: # schema URL/path -> the file globs it applies to
   "https://example.com/my-schema.json":
     - "clusters/**/*.yaml"
-fluxSubstitutions: true     # treat ${VAR} Flux postBuild substitutions as valid
-customTags: ["!secret"]     # extra YAML tags to accept without error
-renderDebounceMs: 200       # debounce for the Flux render pipeline
-renderTimeoutMs: 30000      # max time a single render may run (deadline)
+fluxSubstitutions: true # treat ${VAR} Flux postBuild substitutions as valid
+customTags: ["!secret"] # extra YAML tags to accept without error
+renderDebounceMs: 200 # debounce for the Flux render pipeline
+renderTimeoutMs: 30000 # max time a single render may run (deadline)
 ```
 
 See `.yayamlls.yaml.example` in the repo root for the full set.
@@ -65,9 +65,10 @@ suppress only when the schema is wrong or a value is intentionally
 non-conformant.
 
 ```yaml
-foo: bar  # yayamlls-disable-line   # suppresses this line
+foo: bar # yayamlls-disable-line   # suppresses this line
 # yayamlls-disable-line
-baz: qux                            # suppresses the line below the directive
+baz: qux # suppresses the line below the directive
+
 
 # yayamlls-disable
 # ... suppressed block ...
@@ -82,7 +83,7 @@ The directive must be the first token of the comment.
 
 With `kubernetes` enabled, opening a Flux `HelmRelease` or `Kustomization`
 renders the resource (via the embedded `flate` engine) and surfaces schema
-violations from the *rendered* manifests back on the source document, tagged
+violations from the _rendered_ manifests back on the source document, tagged
 `[rendered <kind>/<name> @ <jsonptr>]`. So a diagnostic may point at the source
 file but describe a problem in the rendered output — read the tag to tell which.
 

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -22,11 +22,11 @@ Zed bundles `yaml-language-server`. To run `yayamlls` instead, in
 
 ```jsonc
 {
-    "languages": {
-        "YAML": {
-            "language_servers": ["yayamlls", "!yaml-language-server"],
-        },
+  "languages": {
+    "YAML": {
+      "language_servers": ["yayamlls", "!yaml-language-server"],
     },
+  },
 }
 ```
 
@@ -37,21 +37,19 @@ Pass server options under the `yayamlls` LSP key; they are forwarded verbatim as
 
 ```jsonc
 {
-    "lsp": {
-        "yayamlls": {
-            "binary": {
-                "path": "/usr/local/bin/yayamlls", // optional: skip the download
-            },
-            "initialization_options": {
-                "catalog": true,
-                "schemas": {
-                    "https://json.schemastore.org/github-workflow.json": [
-                        ".github/workflows/*.yml",
-                    ],
-                },
-            },
+  "lsp": {
+    "yayamlls": {
+      "binary": {
+        "path": "/usr/local/bin/yayamlls", // optional: skip the download
+      },
+      "initialization_options": {
+        "catalog": true,
+        "schemas": {
+          "https://json.schemastore.org/github-workflow.json": [".github/workflows/*.yml"],
         },
+      },
     },
+  },
 }
 ```
 


### PR DESCRIPTION
Mirrors the canonical change in home-operations/.github#37.

`oxfmt` applies a markdown file's `tabWidth` to embedded code blocks. With `[*.md] indent_size = 4`, yaml examples inside the docs get rewritten to 4-space indentation while the yaml files they document stay at 2 under `[*] indent_size = 2`. Anyone copying from the README gets the wrong style. This sets `[*.md] indent_size = 2`.

The reformat is cosmetic: verified across the org that rendered markdown structure is unchanged (no new indented-code-blocks, identical list nesting) and that embedded yaml parses to identical values, block scalars included. Reindented with the repo's pinned oxfmt.