### PR TITLE
ci: ignore github-env for the installer action

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -7,3 +7,8 @@ rules:
   cache-poisoning:
     ignore:
       - goreleaser.yaml
+  # The action installs yayamlls into its own directory (inputs.bindir, else a
+  # RUNNER_TOOL_CACHE subpath) and must put it on PATH for later steps.
+  github-env:
+    ignore:
+      - action.yml


### PR DESCRIPTION
zizmor flags `action/action.yml` with `github-env` (high severity, **low** confidence): the action appends its install directory to `GITHUB_PATH` so later steps can run `yayamlls`. That is the action's entire purpose, and the directory is either `inputs.bindir` or a `RUNNER_TOOL_CACHE` subpath the action itself computes.

Ignored through `.github/zizmor.yml` rather than an inline comment, alongside the existing `cache-poisoning` entry.

Worth landing before #120: once this repository calls the shared workflow-lint action, this finding fails CI.