### PR TITLE
ci: update workflow-lint and use self-repository syntax

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
 
   goreleaser:
     name: GoReleaser
-    uses: ./.github/workflows/goreleaser.yaml
+    uses: $/.github/workflows/goreleaser.yaml
     permissions:
       contents: read
     with:
@@ -123,7 +123,7 @@ jobs:
           echo "zizmor=$(mise config get tools.zizmor)" >> "$GITHUB_OUTPUT"
 
       - name: Lint workflows
-        uses: home-operations/.github/actions/workflow-lint@dfa0b198336d33dcbe73557a68315d3071ec7709 # workflow-lint-1.0.0
+        uses: home-operations/.github/actions/workflow-lint@5514ee499e8919d394b5376637025535dac84ff8 # workflow-lint-v1.0.2
         with:
           actionlint-version: ${{ steps.tools.outputs.actionlint }}
           zizmor-version: ${{ steps.tools.outputs.zizmor }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,7 @@ jobs:
   goreleaser:
     name: GoReleaser
     if: ${{ github.event_name == 'release' }}
-    uses: ./.github/workflows/goreleaser.yaml
+    uses: $/.github/workflows/goreleaser.yaml
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Bump `home-operations/.github/actions/workflow-lint` from 1.0.0 to v1.0.2.

v1.0.1 pins tool versions and v1.0.2 makes actionlint ignore its false errors on GitHub's new `$/` self-repository `uses:` syntax, so workflows adopting `$/` lint clean.

Switch same-repository `uses:` references from `./` to the `$/` self-repository syntax ([changelog](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/)). `$/` resolves to this repository at the exact commit that is running, works everywhere `./` does, and is now the recommended form; the bumped workflow-lint v1.0.2 is what makes it lint clean.