### PR TITLE
feat: add parameter expressions for k8s url formatting

### DIFF
--- a/.yayamlls.yaml.example
+++ b/.yayamlls.yaml.example
@@ -16,8 +16,9 @@ catalog: true
 #   enabled: false
 #   # Override the auto-detect URL template. Placeholders:
 #   # {group}, {groupSeg}, {groupFirst}, {groupFirstSeg}, {kind}, {kindLower},
-#   # {version}, {versionLower}.
-#   # schemaUrl: "https://schemas.example.com/{groupSeg}{kindLower}_{versionLower}.json"
+#   # {version}, {versionLower}. Expression syntax (shell-like):
+#   # {var:-word}, {var:+word}.
+#   # schemaUrl: "https://schemas.example.com/{group:-core}/{kindLower}_{versionLower}.json"
 
 # Per-renderer config. Defaults shown — only set when overriding.
 #

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Per-document schema resolution, highest priority first:
 
 Multi-doc files validate each document against its own schema. The
 default `kubernetes.schemaUrl` is
-`https://k8s-schemas.home-operations.com/{groupSeg}{kindLower}_{versionLower}.json`;
+`https://k8s-schemas.home-operations.com/{group:-core}/{kindLower}_{versionLower}.json`;
 override in `.yayamlls.yaml` to point elsewhere. 404s are silently skipped.
 
 Kubernetes support — apiVersion+kind detection, Flux rendering, and code
@@ -276,9 +276,10 @@ catalogUrl: ""
 # enabled: false to run as a generic YAML language server. schemaUrl overrides
 # the lookup template; placeholders: {group}, {groupSeg}, {groupFirst},
 # {groupFirstSeg}, {kind}, {kindLower}, {version}, {versionLower}.
+# Expression syntax (shell-like): {var:-word}, {var:+word}.
 # kubernetes:
 #   enabled: false
-#   schemaUrl: "https://schemas.example.com/{groupSeg}{kindLower}_{versionLower}.json"
+#   schemaUrl: "https://schemas.example.com/{group:-core}/{kindLower}_{versionLower}.json"
 
 # Optional. Defaults shown.
 # renderers:

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -79,7 +79,7 @@
         "yayamlls.kubernetes.schemaUrl": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Override the Kubernetes auto-detect URL template. Placeholders: `{group}`, `{groupSeg}`, `{kind}`, `{kindLower}`, `{version}`, `{versionLower}`, etc."
+          "markdownDescription": "Override the Kubernetes auto-detect URL template. Placeholders: `{group}`, `{groupSeg}`, `{groupFirst}`, `{groupFirstSeg}`, `{kind}`, `{kindLower}`, `{version}`, `{versionLower}`, etc. Expression syntax: `{var:-word}`, `{var:+word}`."
         },
         "yayamlls.flate.enabled": {
           "type": "boolean",

--- a/internal/schema/embedded/yayamlls.schema.json
+++ b/internal/schema/embedded/yayamlls.schema.json
@@ -32,7 +32,7 @@
         },
         "schemaUrl": {
           "type": "string",
-          "description": "URL template for Kubernetes schema lookup. Placeholders: {group}, {groupSeg}, {groupFirst}, {groupFirstSeg}, {kind}, {kindLower}, {version}, {versionLower}."
+          "description": "URL template for Kubernetes schema lookup. Placeholders: {group}, {groupSeg}, {groupFirst}, {groupFirstSeg}, {kind}, {kindLower}, {version}, {versionLower}. Expression syntax (shell-like): {var:-word}, {var:+word}."
         }
       }
     },

--- a/internal/schema/k8s.go
+++ b/internal/schema/k8s.go
@@ -1,9 +1,14 @@
 package schema
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 const DefaultK8sSchemaURL = "https://k8s-schemas.home-operations.com/" +
-	"{groupSeg}{kindLower}_{versionLower}.json"
+	"{group:-core}/{kindLower}_{versionLower}.json"
+
+var exprRe = regexp.MustCompile(`\{([^}]+)\}`)
 
 // BuildK8sURL renders a URL template against a GVK. Supported placeholders:
 //
@@ -13,6 +18,11 @@ const DefaultK8sSchemaURL = "https://k8s-schemas.home-operations.com/" +
 //	{groupFirstSeg} "<groupFirst>-" or ""
 //	{kind}          {kindLower}
 //	{version}       {versionLower}
+//
+// Expression syntax (shell-like parameter expansion):
+//
+//	{var:-word}     "word" if var is empty, else var
+//	{var:+word}     "word" if var is non-empty, else ""
 func BuildK8sURL(template, group, version, kind string) string {
 	if version == "" || kind == "" {
 		return ""
@@ -29,6 +39,41 @@ func BuildK8sURL(template, group, version, kind string) string {
 	if groupFirst != "" {
 		groupFirstSeg = groupFirst + "-"
 	}
+
+	vars := map[string]string{
+		"group":         group,
+		"groupSeg":      groupSeg,
+		"groupFirst":    groupFirst,
+		"groupFirstSeg": groupFirstSeg,
+		"kind":          strings.ToLower(kind),
+		"kindLower":     strings.ToLower(kind),
+		"version":       strings.ToLower(version),
+		"versionLower":  strings.ToLower(version),
+	}
+
+	template = exprRe.ReplaceAllStringFunc(template, func(match string) string {
+		inner := match[1 : len(match)-1]
+
+		if name, word, ok := strings.Cut(inner, ":-"); ok {
+			if val, exists := vars[name]; exists && val != "" {
+				return val
+			}
+			return word
+		}
+
+		if name, word, ok := strings.Cut(inner, ":+"); ok {
+			if val, exists := vars[name]; exists && val != "" {
+				return word
+			}
+			return ""
+		}
+
+		if val, ok := vars[inner]; ok {
+			return val
+		}
+		return match
+	})
+
 	r := strings.NewReplacer(
 		"{group}", group,
 		"{groupSeg}", groupSeg,

--- a/internal/schema/k8s_test.go
+++ b/internal/schema/k8s_test.go
@@ -15,7 +15,7 @@ func TestBuildK8sURL_DefaultPointsAtHomeOperations(t *testing.T) {
 
 func TestBuildK8sURL_DefaultCoreResource(t *testing.T) {
 	got := BuildK8sURL("", "", "v1", "Pod")
-	want := "https://k8s-schemas.home-operations.com/pod_v1.json"
+	want := "https://k8s-schemas.home-operations.com/core/pod_v1.json"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -63,5 +63,78 @@ func TestBuildK8sURL_AllPlaceholdersResolve(t *testing.T) {
 	got := BuildK8sURL(tmpl, "apps.k8s.io", "v1beta1", "Deployment")
 	if strings.Contains(got, "{") || strings.Contains(got, "}") {
 		t.Errorf("unsubstituted placeholder leaked: %q", got)
+	}
+}
+
+func TestBuildK8sURL_ExprDefaultOnEmpty(t *testing.T) {
+	tests := []struct {
+		name  string
+		group string
+		want  string
+		tmpl  string
+	}{
+		{name: "empty gets 'core' fallback", group: "", tmpl: "{group:-core}", want: "core"},
+		{name: "'apps' keeps value", group: "apps", tmpl: "{group:-core}", want: "apps"},
+		{name: "empty gets 'test' fallback", group: "", tmpl: "{group:-test}", want: "test"},
+		{name: "'batch' keeps value", group: "batch", tmpl: "{group:-default}", want: "batch"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BuildK8sURL(tc.tmpl, tc.group, "v1", "Resource"); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildK8sURL_ExprAltOnNonEmpty(t *testing.T) {
+	tests := []struct {
+		name  string
+		group string
+		want  string
+		tmpl  string
+	}{
+		{name: "empty gets empty", group: "", tmpl: "{group:+/}", want: ""},
+		{name: "'apps' gets '/'", group: "apps", tmpl: "{group:+/}", want: "/"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BuildK8sURL(tc.tmpl, tc.group, "v1", "Resource"); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildK8sURL_ExprSimpleSubstitution(t *testing.T) {
+	if got := BuildK8sURL("{group}", "", "v1", "Namespace"); got != "" {
+		t.Errorf("core: got %q", got)
+	}
+	if got := BuildK8sURL("{group}", "apps", "v1", "Resource"); got != "apps" {
+		t.Errorf("got %q, want apps", got)
+	}
+	if got := BuildK8sURL("{kind}", "apps", "v1", "Deployment"); got != "deployment" {
+		t.Errorf("got %q, want deployment", got)
+	}
+}
+
+func TestBuildK8sURL_ExprComposeGroupSeg(t *testing.T) {
+	tmpl := "{group:-core}/{kindLower}_{versionLower}.json"
+
+	if got := BuildK8sURL(tmpl, "", "v1", "Namespace"); got != "core/namespace_v1.json" {
+		t.Errorf("core: got %q", got)
+	}
+	if got := BuildK8sURL(tmpl, "apps", "v1", "Deployment"); got != "apps/deployment_v1.json" {
+		t.Errorf("grouped: got %q", got)
+	}
+	if got := BuildK8sURL(tmpl, "rbac.authorization.k8s.io", "v1", "ClusterRole"); got != "rbac.authorization.k8s.io/clusterrole_v1.json" {
+		t.Errorf("dotted group: got %q", got)
+	}
+}
+
+func TestBuildK8sURL_ExprPreservesUnknownPlaceholders(t *testing.T) {
+	tmpl := "{unknown}/{group}"
+	if got := BuildK8sURL(tmpl, "apps", "v1", "Deployment"); got != "{unknown}/apps" {
+		t.Errorf("got %q", got)
 	}
 }


### PR DESCRIPTION
## Overview

Fixes #140

Adds shell-like parameter expansion expressions in URL templates:

- `{var:-word}`: expands to `word` when var is empty, otherwise var (e.g. `{group:-core}` maps the empty group to `core`)
- `{var:+word}`: expands to `word` when var is non-empty, otherwise nothing

With this change, the new default schema URL template is now `{group:-core}/{kindLower}_{versionLower}.json`, so built-in core resources (empty group) resolve to `/core/...`

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: Yes, for the initial draft and review.