### PR TITLE
feat!: add case operators for k8s url formatting

### DIFF
--- a/.yayamlls.yaml.example
+++ b/.yayamlls.yaml.example
@@ -15,10 +15,10 @@ catalog: true
 # kubernetes:
 #   enabled: false
 #   # Override the auto-detect URL template. Placeholders:
-#   # {group}, {groupSeg}, {groupFirst}, {groupFirstSeg}, {kind}, {kindLower},
-#   # {version}, {versionLower}. Expression syntax (shell-like):
-#   # {var:-word}, {var:+word}.
-#   # schemaUrl: "https://schemas.example.com/{group:-core}/{kindLower}_{versionLower}.json"
+#   # {group}, {groupSeg}, {groupFirst}, {groupFirstSeg}, {kind}, {version}.
+#   # Expression syntax (shell-like):
+#   # {var:-word}, {var:+word}, {var@U}, {var@L}.
+#   # schemaUrl: "https://schemas.example.com/{group:-core}/{kind@L}_{version@L}.json"
 
 # Per-renderer config. Defaults shown — only set when overriding.
 #

--- a/.yayamlls.yaml.example
+++ b/.yayamlls.yaml.example
@@ -15,7 +15,7 @@ catalog: true
 # kubernetes:
 #   enabled: false
 #   # Override the auto-detect URL template. Placeholders:
-#   # {group}, {groupSeg}, {groupFirst}, {groupFirstSeg}, {kind}, {version}.
+#   # {group}, {groupFirst}, {kind}, {version}.
 #   # Expression syntax (shell-like):
 #   # {var:-word}, {var:+word}, {var@U}, {var@L}.
 #   # schemaUrl: "https://schemas.example.com/{group:-core}/{kind@L}_{version@L}.json"

--- a/README.md
+++ b/README.md
@@ -274,8 +274,7 @@ catalogUrl: ""
 
 # Optional. Kubernetes apiVersion+kind auto-detect (on by default). Set
 # enabled: false to run as a generic YAML language server. schemaUrl overrides
-# the lookup template; placeholders: {group}, {groupSeg}, {groupFirst},
-# {groupFirstSeg}, {kind}, {version}.
+# the lookup template; placeholders: {group}, {groupFirst}, {kind}, {version}.
 # Expression syntax (shell-like): {var:-word}, {var:+word}, {var@U}, {var@L}.
 # kubernetes:
 #   enabled: false

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Per-document schema resolution, highest priority first:
 
 Multi-doc files validate each document against its own schema. The
 default `kubernetes.schemaUrl` is
-`https://k8s-schemas.home-operations.com/{group:-core}/{kindLower}_{versionLower}.json`;
+`https://k8s-schemas.home-operations.com/{group:-core}/{kind@L}_{version@L}.json`;
 override in `.yayamlls.yaml` to point elsewhere. 404s are silently skipped.
 
 Kubernetes support — apiVersion+kind detection, Flux rendering, and code
@@ -275,11 +275,11 @@ catalogUrl: ""
 # Optional. Kubernetes apiVersion+kind auto-detect (on by default). Set
 # enabled: false to run as a generic YAML language server. schemaUrl overrides
 # the lookup template; placeholders: {group}, {groupSeg}, {groupFirst},
-# {groupFirstSeg}, {kind}, {kindLower}, {version}, {versionLower}.
-# Expression syntax (shell-like): {var:-word}, {var:+word}.
+# {groupFirstSeg}, {kind}, {version}.
+# Expression syntax (shell-like): {var:-word}, {var:+word}, {var@U}, {var@L}.
 # kubernetes:
 #   enabled: false
-#   schemaUrl: "https://schemas.example.com/{group:-core}/{kindLower}_{versionLower}.json"
+#   schemaUrl: "https://schemas.example.com/{group:-core}/{kind@L}_{version@L}.json"
 
 # Optional. Defaults shown.
 # renderers:

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -79,7 +79,7 @@
         "yayamlls.kubernetes.schemaUrl": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Override the Kubernetes auto-detect URL template. Placeholders: `{group}`, `{groupSeg}`, `{groupFirst}`, `{groupFirstSeg}`, `{kind}`, `{version}`, etc. Expression syntax: `{var:-word}`, `{var:+word}`, `{var@U}`, `{var@L}`."
+          "markdownDescription": "Override the Kubernetes auto-detect URL template. Placeholders: `{group}`, `{groupFirst}`, `{kind}`, `{version}`, etc. Expression syntax: `{var:-word}`, `{var:+word}`, `{var@U}`, `{var@L}`."
         },
         "yayamlls.flate.enabled": {
           "type": "boolean",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -79,7 +79,7 @@
         "yayamlls.kubernetes.schemaUrl": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Override the Kubernetes auto-detect URL template. Placeholders: `{group}`, `{groupSeg}`, `{groupFirst}`, `{groupFirstSeg}`, `{kind}`, `{kindLower}`, `{version}`, `{versionLower}`, etc. Expression syntax: `{var:-word}`, `{var:+word}`."
+          "markdownDescription": "Override the Kubernetes auto-detect URL template. Placeholders: `{group}`, `{groupSeg}`, `{groupFirst}`, `{groupFirstSeg}`, `{kind}`, `{version}`, etc. Expression syntax: `{var:-word}`, `{var:+word}`, `{var@U}`, `{var@L}`."
         },
         "yayamlls.flate.enabled": {
           "type": "boolean",

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -87,9 +87,9 @@ func TestMerge_UnionsGlobsForSameSchema(t *testing.T) {
 
 func TestMerge_CarriesKubernetes(t *testing.T) {
 	base := Settings{}
-	override := Settings{Kubernetes: &KubernetesSettings{SchemaURL: "https://mirror.example/{kindLower}.json"}}
+	override := Settings{Kubernetes: &KubernetesSettings{SchemaURL: "https://mirror.example/{kind}.json"}}
 	got := Merge(base, override)
-	if got.Kubernetes == nil || got.Kubernetes.SchemaURL != "https://mirror.example/{kindLower}.json" {
+	if got.Kubernetes == nil || got.Kubernetes.SchemaURL != "https://mirror.example/{kind}.json" {
 		t.Errorf("override kubernetes.schemaUrl dropped: %+v", got.Kubernetes)
 	}
 }
@@ -97,12 +97,12 @@ func TestMerge_CarriesKubernetes(t *testing.T) {
 func TestMerge_KubernetesFieldMerge(t *testing.T) {
 	// A workspace opt-out must survive an override that only sets schemaUrl.
 	base := Settings{Kubernetes: &KubernetesSettings{Enabled: new(false)}}
-	override := Settings{Kubernetes: &KubernetesSettings{SchemaURL: "https://mirror/{kindLower}.json"}}
+	override := Settings{Kubernetes: &KubernetesSettings{SchemaURL: "https://mirror/{kind}.json"}}
 	got := Merge(base, override)
 	if got.Kubernetes.Enabled == nil || *got.Kubernetes.Enabled {
 		t.Errorf("enabled:false dropped by partial override: %+v", got.Kubernetes)
 	}
-	if got.Kubernetes.SchemaURL != "https://mirror/{kindLower}.json" {
+	if got.Kubernetes.SchemaURL != "https://mirror/{kind}.json" {
 		t.Errorf("schemaUrl not merged: %+v", got.Kubernetes)
 	}
 	// Merge must not mutate base's pointee.

--- a/internal/lint/cli_render_test.go
+++ b/internal/lint/cli_render_test.go
@@ -40,7 +40,7 @@ func renderWorkspace(t *testing.T) string {
 	}`
 	mustWrite(t, filepath.Join(root, "fakekind.json"), schema)
 	mustWrite(t, filepath.Join(root, ".yayamlls.yaml"),
-		"catalog: false\nkubernetes:\n  schemaUrl: \"file://"+filepath.Join(root, "{kindLower}.json")+"\"\n")
+		"catalog: false\nkubernetes:\n  schemaUrl: \"file://"+filepath.Join(root, "{kind@L}.json")+"\"\n")
 	return root
 }
 

--- a/internal/lsp/reload_test.go
+++ b/internal/lsp/reload_test.go
@@ -70,7 +70,7 @@ func TestSettings_OverridesSurviveWorkspaceFolderChange(t *testing.T) {
 
 	// A client pushes kubernetes.schemaUrl via didChangeConfiguration.
 	if err := s.didChangeConfig(rec.ctx(), &protocol.DidChangeConfigurationParams{
-		Settings: map[string]any{"kubernetes": map[string]any{"schemaUrl": "https://mirror/{kindLower}.json"}},
+		Settings: map[string]any{"kubernetes": map[string]any{"schemaUrl": "https://mirror/{kind}.json"}},
 	}); err != nil {
 		t.Fatalf("didChangeConfig: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestSettings_OverridesSurviveWorkspaceFolderChange(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("didChangeWorkspaceFolders: %v", err)
 	}
-	if s.settings.Kubernetes == nil || s.settings.Kubernetes.SchemaURL != "https://mirror/{kindLower}.json" {
+	if s.settings.Kubernetes == nil || s.settings.Kubernetes.SchemaURL != "https://mirror/{kind}.json" {
 		t.Errorf("override dropped after workspace-folder change: %+v", s.settings.Kubernetes)
 	}
 }

--- a/internal/schema/embedded/yayamlls.schema.json
+++ b/internal/schema/embedded/yayamlls.schema.json
@@ -32,7 +32,7 @@
         },
         "schemaUrl": {
           "type": "string",
-          "description": "URL template for Kubernetes schema lookup. Placeholders: {group}, {groupSeg}, {groupFirst}, {groupFirstSeg}, {kind}, {version}. Expression syntax (shell-like): {var:-word}, {var:+word}, {var@U}, {var@L}."
+          "description": "URL template for Kubernetes schema lookup. Placeholders: {group}, {groupFirst}, {kind}, {version}. Expression syntax (shell-like): {var:-word}, {var:+word}, {var@U}, {var@L}."
         }
       }
     },

--- a/internal/schema/embedded/yayamlls.schema.json
+++ b/internal/schema/embedded/yayamlls.schema.json
@@ -32,7 +32,7 @@
         },
         "schemaUrl": {
           "type": "string",
-          "description": "URL template for Kubernetes schema lookup. Placeholders: {group}, {groupSeg}, {groupFirst}, {groupFirstSeg}, {kind}, {kindLower}, {version}, {versionLower}. Expression syntax (shell-like): {var:-word}, {var:+word}."
+          "description": "URL template for Kubernetes schema lookup. Placeholders: {group}, {groupSeg}, {groupFirst}, {groupFirstSeg}, {kind}, {version}. Expression syntax (shell-like): {var:-word}, {var:+word}, {var@U}, {var@L}."
         }
       }
     },

--- a/internal/schema/embedded_test.go
+++ b/internal/schema/embedded_test.go
@@ -13,7 +13,7 @@ func TestEmbeddedYamllsSchema_LoadsAndCompiles(t *testing.T) {
 	good := map[string]any{
 		"catalog": true,
 		"kubernetes": map[string]any{
-			"schemaUrl": "https://example.com/{kindLower}.json",
+			"schemaUrl": "https://example.com/{kind}.json",
 		},
 	}
 	if err := sch.Validate(good); err != nil {

--- a/internal/schema/k8s.go
+++ b/internal/schema/k8s.go
@@ -21,13 +21,13 @@ func varsReplacer(m map[string]string) *strings.Replacer {
 // BuildK8sURL renders a URL template against a GVK. Supported placeholders:
 //
 //	{group}         full api group, "" for core
-//	{groupSeg}      "<group>/" or ""
 //	{groupFirst}    first DNS label of the group
-//	{groupFirstSeg} "<groupFirst>-" or ""
 //	{kind}          the resource kind
 //	{version}       the api version
 //	{kindLower}     legacy alias for {kind@L}
 //	{versionLower}  legacy alias for {version@L}
+//	{groupSeg}      legacy alias for {group}{group:+/}
+//	{groupFirstSeg} legacy alias for {groupFirst}{groupFirst:+-}
 //
 // Expression syntax (shell-like parameter expansion):
 //

--- a/internal/schema/k8s.go
+++ b/internal/schema/k8s.go
@@ -6,7 +6,7 @@ import (
 )
 
 const DefaultK8sSchemaURL = "https://k8s-schemas.home-operations.com/" +
-	"{group:-core}/{kindLower}_{versionLower}.json"
+	"{group:-core}/{kind@L}_{version@L}.json"
 
 var exprRe = regexp.MustCompile(`\{([^}]+)\}`)
 
@@ -24,13 +24,17 @@ func varsReplacer(m map[string]string) *strings.Replacer {
 //	{groupSeg}      "<group>/" or ""
 //	{groupFirst}    first DNS label of the group
 //	{groupFirstSeg} "<groupFirst>-" or ""
-//	{kind}          {kindLower}
-//	{version}       {versionLower}
+//	{kind}          the resource kind
+//	{version}       the api version
+//	{kindLower}     legacy alias for {kind@L}
+//	{versionLower}  legacy alias for {version@L}
 //
 // Expression syntax (shell-like parameter expansion):
 //
 //	{var:-word}     "word" if var is empty, else var
 //	{var:+word}     "word" if var is non-empty, else ""
+//	{var@U}         var but uppercased
+//	{var@L}         var but lowercased
 func BuildK8sURL(template, group, version, kind string) string {
 	if version == "" || kind == "" {
 		return ""
@@ -53,9 +57,9 @@ func BuildK8sURL(template, group, version, kind string) string {
 		"groupSeg":      groupSeg,
 		"groupFirst":    groupFirst,
 		"groupFirstSeg": groupFirstSeg,
-		"kind":          strings.ToLower(kind),
+		"kind":          kind,
 		"kindLower":     strings.ToLower(kind),
-		"version":       strings.ToLower(version),
+		"version":       version,
 		"versionLower":  strings.ToLower(version),
 	}
 
@@ -74,6 +78,20 @@ func BuildK8sURL(template, group, version, kind string) string {
 				return word
 			}
 			return ""
+		}
+
+		if name, operator, ok := strings.Cut(inner, "@"); ok {
+			if val, exists := vars[name]; exists {
+				switch operator {
+				case "U":
+					return strings.ToUpper(val)
+				case "L":
+					return strings.ToLower(val)
+				}
+			}
+
+			// ignore undefined operators
+			inner = name
 		}
 
 		if val, ok := vars[inner]; ok {

--- a/internal/schema/k8s.go
+++ b/internal/schema/k8s.go
@@ -10,6 +10,14 @@ const DefaultK8sSchemaURL = "https://k8s-schemas.home-operations.com/" +
 
 var exprRe = regexp.MustCompile(`\{([^}]+)\}`)
 
+func varsReplacer(m map[string]string) *strings.Replacer {
+	args := make([]string, 0, len(m)*2)
+	for k, v := range m {
+		args = append(args, "{"+k+"}", v)
+	}
+	return strings.NewReplacer(args...)
+}
+
 // BuildK8sURL renders a URL template against a GVK. Supported placeholders:
 //
 //	{group}         full api group, "" for core
@@ -74,15 +82,6 @@ func BuildK8sURL(template, group, version, kind string) string {
 		return match
 	})
 
-	r := strings.NewReplacer(
-		"{group}", group,
-		"{groupSeg}", groupSeg,
-		"{groupFirst}", groupFirst,
-		"{groupFirstSeg}", groupFirstSeg,
-		"{kind}", strings.ToLower(kind),
-		"{kindLower}", strings.ToLower(kind),
-		"{version}", strings.ToLower(version),
-		"{versionLower}", strings.ToLower(version),
-	)
+	r := varsReplacer(vars)
 	return r.Replace(template)
 }

--- a/internal/schema/k8s_test.go
+++ b/internal/schema/k8s_test.go
@@ -22,7 +22,7 @@ func TestBuildK8sURL_DefaultCoreResource(t *testing.T) {
 }
 
 func TestBuildK8sURL_TemplatePlaceholders(t *testing.T) {
-	tmpl := "https://schemas.example.com/{groupSeg}{kind@L}_{version@L}.json"
+	tmpl := "https://schemas.example.com/{group}{group:+/}{kind@L}_{version@L}.json"
 	got := BuildK8sURL(tmpl, "helm.toolkit.fluxcd.io", "v2", "HelmRelease")
 	want := "https://schemas.example.com/helm.toolkit.fluxcd.io/helmrelease_v2.json"
 	if got != want {
@@ -31,7 +31,7 @@ func TestBuildK8sURL_TemplatePlaceholders(t *testing.T) {
 }
 
 func TestBuildK8sURL_YannhLayoutViaTemplate(t *testing.T) {
-	tmpl := "https://yannh.example/{kind@L}-{groupFirstSeg}{version@L}.json"
+	tmpl := "https://yannh.example/{kind@L}-{groupFirst}{groupFirst:+-}{version@L}.json"
 	if got := BuildK8sURL(tmpl, "", "v1", "Pod"); got != "https://yannh.example/pod-v1.json" {
 		t.Errorf("core: got %q", got)
 	}
@@ -331,5 +331,67 @@ func TestBuildK8sURL_LegacyVarsMatchOperators(t *testing.T) {
 	operators := BuildK8sURL("{kind@L}_{version@L}", "apps", "V1Beta1", "Deployment")
 	if legacy != operators {
 		t.Errorf("legacy %q != operator form %q", legacy, operators)
+	}
+}
+
+func TestBuildK8sURL_LegacySegVars(t *testing.T) {
+	tests := []struct {
+		name  string
+		tmpl  string
+		group string
+		want  string
+	}{
+		{
+			name: "groupSeg core",
+			tmpl: "{groupSeg}",
+			want: "",
+		},
+		{
+			name:  "groupSeg grouped",
+			tmpl:  "{groupSeg}",
+			group: "apps",
+			want:  "apps/",
+		},
+		{
+			name:  "groupSeg dotted",
+			tmpl:  "{groupSeg}",
+			group: "rbac.authorization.k8s.io",
+			want:  "rbac.authorization.k8s.io/",
+		},
+		{
+			name: "groupFirstSeg core",
+			tmpl: "{groupFirstSeg}",
+			want: "",
+		},
+		{
+			name:  "groupFirstSeg grouped",
+			tmpl:  "{groupFirstSeg}",
+			group: "apps",
+			want:  "apps-",
+		},
+		{
+			name:  "groupFirstSeg dotted",
+			tmpl:  "{groupFirstSeg}",
+			group: "rbac.authorization.k8s.io",
+			want:  "rbac-",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BuildK8sURL(tc.tmpl, tc.group, "v1", "Resource"); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildK8sURL_LegacySegVarsMatchComposition(t *testing.T) {
+	for _, group := range []string{"", "apps", "rbac.authorization.k8s.io"} {
+		if got, want := BuildK8sURL("{groupSeg}", group, "v1", "Resource"), BuildK8sURL("{group}{group:+/}", group, "v1", "Resource"); got != want {
+			t.Errorf("group %q: {groupSeg} %q != {group}{group:+/} %q", group, got, want)
+		}
+		if got, want := BuildK8sURL("{groupFirstSeg}", group, "v1", "Resource"), BuildK8sURL("{groupFirst}{groupFirst:+-}", group, "v1", "Resource"); got != want {
+			t.Errorf("group %q: {groupFirstSeg} %q != {groupFirst}{groupFirst:+-} %q", group, got, want)
+		}
 	}
 }

--- a/internal/schema/k8s_test.go
+++ b/internal/schema/k8s_test.go
@@ -22,7 +22,7 @@ func TestBuildK8sURL_DefaultCoreResource(t *testing.T) {
 }
 
 func TestBuildK8sURL_TemplatePlaceholders(t *testing.T) {
-	tmpl := "https://schemas.example.com/{groupSeg}{kindLower}_{versionLower}.json"
+	tmpl := "https://schemas.example.com/{groupSeg}{kind@L}_{version@L}.json"
 	got := BuildK8sURL(tmpl, "helm.toolkit.fluxcd.io", "v2", "HelmRelease")
 	want := "https://schemas.example.com/helm.toolkit.fluxcd.io/helmrelease_v2.json"
 	if got != want {
@@ -31,7 +31,7 @@ func TestBuildK8sURL_TemplatePlaceholders(t *testing.T) {
 }
 
 func TestBuildK8sURL_YannhLayoutViaTemplate(t *testing.T) {
-	tmpl := "https://yannh.example/{kindLower}-{groupFirstSeg}{version}.json"
+	tmpl := "https://yannh.example/{kind@L}-{groupFirstSeg}{version@L}.json"
 	if got := BuildK8sURL(tmpl, "", "v1", "Pod"); got != "https://yannh.example/pod-v1.json" {
 		t.Errorf("core: got %q", got)
 	}
@@ -46,15 +46,6 @@ func TestBuildK8sURL_EmptyWhenMissingFields(t *testing.T) {
 	}
 	if got := BuildK8sURL("", "apps", "v1", ""); got != "" {
 		t.Errorf("missing kind should yield empty, got %q", got)
-	}
-}
-
-func TestBuildK8sURL_KindAndVersionLowercased(t *testing.T) {
-	// The documented contract is {kind} == {kindLower} and {version} ==
-	// {versionLower}; both must be lowercased.
-	got := BuildK8sURL("{kind}_{version}", "apps", "V1Beta1", "Deployment")
-	if got != "deployment_v1beta1" {
-		t.Errorf("got %q, want deployment_v1beta1", got)
 	}
 }
 
@@ -113,21 +104,21 @@ func TestBuildK8sURL_ExprSimpleSubstitution(t *testing.T) {
 	if got := BuildK8sURL("{group}", "apps", "v1", "Resource"); got != "apps" {
 		t.Errorf("got %q, want apps", got)
 	}
-	if got := BuildK8sURL("{kind}", "apps", "v1", "Deployment"); got != "deployment" {
-		t.Errorf("got %q, want deployment", got)
+	if got := BuildK8sURL("{kind}", "apps", "v1", "Deployment"); got != "Deployment" {
+		t.Errorf("got %q, want Deployment", got)
 	}
 }
 
 func TestBuildK8sURL_ExprComposeGroupSeg(t *testing.T) {
-	tmpl := "{group:-core}/{kindLower}_{versionLower}.json"
+	tmpl := "{group:-core}/{kind}_{version}.json"
 
-	if got := BuildK8sURL(tmpl, "", "v1", "Namespace"); got != "core/namespace_v1.json" {
+	if got := BuildK8sURL(tmpl, "", "v1", "Namespace"); got != "core/Namespace_v1.json" {
 		t.Errorf("core: got %q", got)
 	}
-	if got := BuildK8sURL(tmpl, "apps", "v1", "Deployment"); got != "apps/deployment_v1.json" {
+	if got := BuildK8sURL(tmpl, "apps", "v1", "Deployment"); got != "apps/Deployment_v1.json" {
 		t.Errorf("grouped: got %q", got)
 	}
-	if got := BuildK8sURL(tmpl, "rbac.authorization.k8s.io", "v1", "ClusterRole"); got != "rbac.authorization.k8s.io/clusterrole_v1.json" {
+	if got := BuildK8sURL(tmpl, "rbac.authorization.k8s.io", "v1", "ClusterRole"); got != "rbac.authorization.k8s.io/ClusterRole_v1.json" {
 		t.Errorf("dotted group: got %q", got)
 	}
 }
@@ -136,5 +127,209 @@ func TestBuildK8sURL_ExprPreservesUnknownPlaceholders(t *testing.T) {
 	tmpl := "{unknown}/{group}"
 	if got := BuildK8sURL(tmpl, "apps", "v1", "Deployment"); got != "{unknown}/apps" {
 		t.Errorf("got %q", got)
+	}
+}
+
+func TestBuildK8sURL_ExprUppercaseOperator(t *testing.T) {
+	tests := []struct {
+		name    string
+		tmpl    string
+		group   string
+		version string
+		kind    string
+		want    string
+	}{
+		{
+			name:    "kind@U uppercases kind",
+			tmpl:    "{kind@U}",
+			group:   "apps",
+			version: "v1",
+			kind:    "Deployment",
+			want:    "DEPLOYMENT",
+		},
+		{
+			name:    "version@U uppercases version",
+			tmpl:    "{version@U}",
+			group:   "apps",
+			version: "v1beta1",
+			kind:    "Deployment",
+			want:    "V1BETA1",
+		},
+		{
+			name:    "group@U uppercases group",
+			tmpl:    "{group@U}",
+			group:   "rbac.authorization.k8s.io",
+			version: "v1",
+			kind:    "Deployment",
+			want:    "RBAC.AUTHORIZATION.K8S.IO",
+		},
+		{
+			name:    "empty value stays empty",
+			tmpl:    "{group@U}",
+			version: "v1",
+			kind:    "Deployment",
+			want:    "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BuildK8sURL(tc.tmpl, tc.group, tc.version, tc.kind); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildK8sURL_ExprLowercaseOperator(t *testing.T) {
+	tests := []struct {
+		name    string
+		tmpl    string
+		group   string
+		version string
+		kind    string
+		want    string
+	}{
+		{
+			name:    "kind@L lowercases kind",
+			tmpl:    "{kind@L}",
+			group:   "apps",
+			version: "v1",
+			kind:    "Deployment",
+			want:    "deployment",
+		},
+		{
+			name:    "version@L lowercases version",
+			tmpl:    "{version@L}",
+			group:   "apps",
+			version: "V1Beta1",
+			kind:    "Deployment",
+			want:    "v1beta1",
+		},
+		{
+			name:    "group@L lowercases group",
+			tmpl:    "{group@L}",
+			group:   "RBAC.Authorization.K8s.IO",
+			version: "v1",
+			kind:    "Deployment",
+			want:    "rbac.authorization.k8s.io",
+		},
+		{
+			name:    "empty value stays empty",
+			tmpl:    "{group@L}",
+			version: "v1",
+			kind:    "Deployment",
+			want:    "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BuildK8sURL(tc.tmpl, tc.group, tc.version, tc.kind); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildK8sURL_ExprUndefinedOperator(t *testing.T) {
+	tests := []struct {
+		name string
+		tmpl string
+		want string
+	}{
+		{
+			name: "known var with unknown operator returns var value",
+			tmpl: "{group@x}",
+			want: "apps",
+		},
+		{
+			name: "unknown var with unknown operator preserved",
+			tmpl: "{unknown@x}",
+			want: "{unknown@x}",
+		},
+		{
+			name: "empty operator returns var value",
+			tmpl: "{kind@}",
+			want: "Deployment",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BuildK8sURL(tc.tmpl, "apps", "v1", "Deployment"); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildK8sURL_LegacyLowercaseVars(t *testing.T) {
+	tests := []struct {
+		name    string
+		tmpl    string
+		group   string
+		version string
+		kind    string
+		want    string
+	}{
+		{
+			name:    "kindLower",
+			tmpl:    "{kindLower}",
+			group:   "apps",
+			version: "v1",
+			kind:    "Deployment",
+			want:    "deployment",
+		},
+		{
+			name:    "versionLower",
+			tmpl:    "{versionLower}",
+			group:   "apps",
+			version: "V1Beta1",
+			kind:    "Deployment",
+			want:    "v1beta1",
+		},
+		{
+			name:    "core default form",
+			tmpl:    "{group:-core}/{kindLower}_{versionLower}.json",
+			version: "V1",
+			kind:    "Namespace",
+			want:    "core/namespace_v1.json",
+		},
+		{
+			name:    "grouped default form",
+			tmpl:    "{group:-core}/{kindLower}_{versionLower}.json",
+			group:   "apps",
+			version: "v1",
+			kind:    "Deployment",
+			want:    "apps/deployment_v1.json",
+		},
+		{
+			name:    "dotted group default form",
+			tmpl:    "{group:-core}/{kindLower}_{versionLower}.json",
+			group:   "rbac.authorization.k8s.io",
+			version: "v1",
+			kind:    "ClusterRole",
+			want:    "rbac.authorization.k8s.io/clusterrole_v1.json",
+		},
+		{
+			name:    "legacy var in expression",
+			tmpl:    "{kindLower:-pod}",
+			version: "v1",
+			kind:    "Deployment",
+			want:    "deployment",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BuildK8sURL(tc.tmpl, tc.group, tc.version, tc.kind); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildK8sURL_LegacyVarsMatchOperators(t *testing.T) {
+	legacy := BuildK8sURL("{kindLower}_{versionLower}", "apps", "V1Beta1", "Deployment")
+	operators := BuildK8sURL("{kind@L}_{version@L}", "apps", "V1Beta1", "Deployment")
+	if legacy != operators {
+		t.Errorf("legacy %q != operator form %q", legacy, operators)
 	}
 }

--- a/test/lsp_multidoc_test.go
+++ b/test/lsp_multidoc_test.go
@@ -19,7 +19,7 @@ func TestMultiDocMixedKinds(t *testing.T) {
 	root := t.TempDir()
 	// Pin yannh so the test doesn't depend on what the default mirror hosts.
 	cfg := `kubernetes:
-  schemaUrl: "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/{kind@L}-{groupFirstSeg}{version}.json"
+  schemaUrl: "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/{kind@L}-{groupFirst}{groupFirst:+-}{version}.json"
 catalog: false
 `
 	if err := os.WriteFile(filepath.Join(root, ".yayamlls.yaml"), []byte(cfg), 0o644); err != nil {

--- a/test/lsp_multidoc_test.go
+++ b/test/lsp_multidoc_test.go
@@ -19,7 +19,7 @@ func TestMultiDocMixedKinds(t *testing.T) {
 	root := t.TempDir()
 	// Pin yannh so the test doesn't depend on what the default mirror hosts.
 	cfg := `kubernetes:
-  schemaUrl: "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/{kindLower}-{groupFirstSeg}{version}.json"
+  schemaUrl: "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/{kind@L}-{groupFirstSeg}{version}.json"
 catalog: false
 `
 	if err := os.WriteFile(filepath.Join(root, ".yayamlls.yaml"), []byte(cfg), 0o644); err != nil {


### PR DESCRIPTION
## Overview

Adds case-transformation operators (`{var@U}`, `{var@L}`) to URL templates, and makes `{kind}`/`{version}` preserve their original case instead of always being lowercased.

- `{var@L}`: expands to the var lowercased (e.g. `{kind@L}` renders `Deployment` as `deployment`)
- `{var@U}`: expands to the var uppercased (e.g. `{version@U}` renders `v1beta1` as `V1BETA1`)

The default schema URL template becomes `{group:-core}/{kind@L}_{version@L}.json`, which renders identically to the previous `{kindLower}_{versionLower}` form.

**Breaking change**: `{kind}` and `{version}` are no longer lowercased. The legacy `{kindLower}`/`{versionLower}` placeholders still work but are deprecated, as are `{groupSeg}`/`{groupFirstSeg}` in favor of the composed forms `{group}{group:+/}` and `{groupFirst}{groupFirst:+-}` (all kept for backward compatibility).

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: Yes. Initial draft, tests and code review are AI-assisted.
