### PR TITLE
feat(schema): parse nested expressions in k8s url templates

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -79,7 +79,7 @@
         "yayamlls.kubernetes.schemaUrl": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Override the Kubernetes auto-detect URL template. Placeholders: `{group}`, `{groupFirst}`, `{kind}`, `{version}`, etc. Expression syntax: `{var:-word}`, `{var:+word}`, `{var@U}`, `{var@L}`."
+          "markdownDescription": "Override the Kubernetes auto-detect URL template. Placeholders: `{group}`, `{groupFirst}`, `{kind}`, `{version}`, etc. Expression syntax: `{var:-word}`, `{var:+word}`, `{var@U}`, `{var@L}`. Nested expressions, e.g. `{{group:-core}@U}` yields `CORE` for an empty group."
         },
         "yayamlls.flate.enabled": {
           "type": "boolean",

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -27,7 +27,7 @@ type KubernetesSettings struct {
 	// is enabled; set false to run as a generic YAML language server.
 	Enabled *bool `json:"enabled,omitempty"`
 	// SchemaURL templates per-document apiVersion+kind auto-detect.
-	// See schema.BuildK8sURL for supported placeholders.
+	// See internal/schema/k8s.go for supported placeholders and expressions.
 	SchemaURL string `json:"schemaUrl,omitempty"`
 }
 

--- a/internal/schema/k8s.go
+++ b/internal/schema/k8s.go
@@ -1,22 +1,12 @@
 package schema
 
 import (
-	"regexp"
+	"fmt"
 	"strings"
 )
 
 const DefaultK8sSchemaURL = "https://k8s-schemas.home-operations.com/" +
 	"{group:-core}/{kind@L}_{version@L}.json"
-
-var exprRe = regexp.MustCompile(`\{([^}]+)\}`)
-
-func varsReplacer(m map[string]string) *strings.Replacer {
-	args := make([]string, 0, len(m)*2)
-	for k, v := range m {
-		args = append(args, "{"+k+"}", v)
-	}
-	return strings.NewReplacer(args...)
-}
 
 // BuildK8sURL renders a URL template against a GVK. Supported placeholders:
 //
@@ -35,9 +25,9 @@ func varsReplacer(m map[string]string) *strings.Replacer {
 //	{var:+word}     "word" if var is non-empty, else ""
 //	{var@U}         var but uppercased
 //	{var@L}         var but lowercased
-func BuildK8sURL(template, group, version, kind string) string {
+func BuildK8sURL(template, group, version, kind string) (string, error) {
 	if version == "" || kind == "" {
-		return ""
+		return "", nil
 	}
 	if template == "" {
 		template = DefaultK8sSchemaURL
@@ -63,43 +53,203 @@ func BuildK8sURL(template, group, version, kind string) string {
 		"versionLower":  strings.ToLower(version),
 	}
 
-	template = exprRe.ReplaceAllStringFunc(template, func(match string) string {
-		inner := match[1 : len(match)-1]
+	nodes, err := parseTemplate(template)
+	if err != nil {
+		return "", err
+	}
+	return evalNodes(nodes, vars)
+}
 
-		if name, word, ok := strings.Cut(inner, ":-"); ok {
-			if val, exists := vars[name]; exists && val != "" {
-				return val
+// node is a parsed template fragment: either literal text or a {expression}.
+type node interface{ isNode() }
+
+// textNode is literal output between expressions.
+type textNode struct{ s string }
+
+func (textNode) isNode() {}
+
+// exprNode is a complete {expression}.
+type exprNode struct{ body *exprBody }
+
+func (exprNode) isNode() {}
+
+// exprBody is an {expression}: a bare operand, or "operand <expr> word".
+type exprBody struct {
+	expr    expression
+	operand string
+	word    string
+}
+
+// operator identifies a {var@op} operator.
+type operator int
+
+const (
+	operatorNone operator = iota
+	operatorUpper
+	operatorLower
+)
+
+func parseTemplate(template string) ([]node, error) {
+	var nodes []node
+	var b strings.Builder
+	for i := 0; i < len(template); {
+		switch template[i] {
+		case '{':
+			if b.Len() > 0 {
+				nodes = append(nodes, textNode{s: b.String()})
+				b.Reset()
 			}
-			return word
-		}
-
-		if name, word, ok := strings.Cut(inner, ":+"); ok {
-			if val, exists := vars[name]; exists && val != "" {
-				return word
+			end, ok := matchBraces(template, i)
+			if !ok {
+				return nil, fmt.Errorf("unterminated expression at %d", i)
 			}
-			return ""
+			nodes = append(nodes, exprNode{body: parseBody(template[i+1 : end-1])})
+			i = end
+		case '}':
+			return nil, fmt.Errorf("unexpected '}' at %d", i)
+		default:
+			b.WriteByte(template[i])
+			i++
 		}
+	}
+	if b.Len() > 0 {
+		nodes = append(nodes, textNode{s: b.String()})
+	}
+	return nodes, nil
+}
 
-		if name, operator, ok := strings.Cut(inner, "@"); ok {
-			if val, exists := vars[name]; exists {
-				switch operator {
-				case "U":
-					return strings.ToUpper(val)
-				case "L":
-					return strings.ToLower(val)
-				}
+func parseBody(body string) *exprBody {
+	exp, idx := findExpression(body)
+	eb := &exprBody{expr: exp}
+	if exp == expressionNone {
+		eb.operand = body
+		return eb
+	}
+	eb.operand = body[:idx]
+	eb.word = body[idx+len(exp.separator()):]
+	return eb
+}
+
+func parseOperator(word string) operator {
+	switch word {
+	case "U":
+		return operatorUpper
+	case "L":
+		return operatorLower
+	}
+	return operatorNone
+}
+
+func matchBraces(s string, start int) (int, bool) {
+	depth := 0
+	for i := start; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1, true
 			}
-
-			// ignore undefined operators
-			inner = name
 		}
+	}
+	return 0, false
+}
 
-		if val, ok := vars[inner]; ok {
-			return val
+func evalNodes(nodes []node, vars map[string]string) (string, error) {
+	var b strings.Builder
+	for _, n := range nodes {
+		switch n := n.(type) {
+		case textNode:
+			b.WriteString(n.s)
+		case exprNode:
+			val, err := evalBody(n.body, vars)
+			if err != nil {
+				return "", err
+			}
+			b.WriteString(val)
 		}
-		return match
-	})
+	}
+	return b.String(), nil
+}
 
-	r := varsReplacer(vars)
-	return r.Replace(template)
+func evalBody(eb *exprBody, vars map[string]string) (string, error) {
+	switch eb.expr {
+	case expressionNone:
+		val, ok := vars[eb.operand]
+		if !ok {
+			return "", fmt.Errorf("unknown placeholder %q", eb.operand)
+		}
+		return val, nil
+	case expressionDefault:
+		if val, ok := vars[eb.operand]; ok && val != "" {
+			return val, nil
+		}
+		return eb.word, nil
+	case expressionAlt:
+		if val, ok := vars[eb.operand]; ok && val != "" {
+			return eb.word, nil
+		}
+		return "", nil
+	case expressionOperator:
+		val, ok := vars[eb.operand]
+		if !ok {
+			return "", fmt.Errorf("unknown placeholder %q", eb.operand)
+		}
+		switch parseOperator(eb.word) {
+		case operatorUpper:
+			return strings.ToUpper(val), nil
+		case operatorLower:
+			return strings.ToLower(val), nil
+		}
+		return "", fmt.Errorf("undefined operator %q on {%s}", eb.word, eb.operand)
+	default:
+		return "", fmt.Errorf("expression %d not implemented", eb.expr)
+	}
+}
+
+type expression int
+
+const (
+	expressionNone expression = iota
+	expressionDefault
+	expressionAlt
+	expressionOperator
+)
+
+func (e expression) separator() string {
+	switch e {
+	case expressionDefault:
+		return ":-"
+	case expressionAlt:
+		return ":+"
+	case expressionOperator:
+		return "@"
+	}
+	return ""
+}
+
+func findExpression(s string) (expression, int) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '{' {
+			end, ok := matchBraces(s, i)
+			if !ok {
+				return expressionNone, -1
+			}
+			i = end - 1
+			continue
+		}
+		switch s[i] {
+		case ':':
+			if i+1 < len(s) && s[i+1] == '-' {
+				return expressionDefault, i
+			}
+			if i+1 < len(s) && s[i+1] == '+' {
+				return expressionAlt, i
+			}
+		case '@':
+			return expressionOperator, i
+		}
+	}
+	return expressionNone, -1
 }

--- a/internal/schema/k8s.go
+++ b/internal/schema/k8s.go
@@ -8,7 +8,14 @@ import (
 const DefaultK8sSchemaURL = "https://k8s-schemas.home-operations.com/" +
 	"{group:-core}/{kind@L}_{version@L}.json"
 
-// BuildK8sURL renders a URL template against a GVK. Supported placeholders:
+// k8sTemplate is a parsed schema URL template. Parsing resolves every
+// placeholder against the known vars and pins each operator, so Render cannot
+// fail.
+type k8sTemplate struct {
+	nodes []node
+}
+
+// parseK8sTemplate parses spec into a render-ready template. Supported placeholders:
 //
 //	{group}         full api group, "" for core
 //	{groupFirst}    first DNS label of the group
@@ -31,39 +38,32 @@ const DefaultK8sSchemaURL = "https://k8s-schemas.home-operations.com/" +
 //
 // A backslash escapes the next character, dropping the backslash: \{ and \}
 // yield literal braces that don't open or close an expression, \x yields x.
-func BuildK8sURL(template, group, version, kind string) (string, error) {
-	if version == "" || kind == "" {
-		return "", nil
+func parseK8sTemplate(spec string) (*k8sTemplate, error) {
+	if spec == "" {
+		spec = DefaultK8sSchemaURL
 	}
-	if template == "" {
-		template = DefaultK8sSchemaURL
-	}
-	groupFirst, _, _ := strings.Cut(group, ".")
-	groupSeg := ""
-	if group != "" {
-		groupSeg = group + "/"
-	}
-	groupFirstSeg := ""
-	if groupFirst != "" {
-		groupFirstSeg = groupFirst + "-"
-	}
-
-	vars := map[string]string{
-		"group":         group,
-		"groupSeg":      groupSeg,
-		"groupFirst":    groupFirst,
-		"groupFirstSeg": groupFirstSeg,
-		"kind":          kind,
-		"kindLower":     strings.ToLower(kind),
-		"version":       version,
-		"versionLower":  strings.ToLower(version),
-	}
-
-	nodes, err := parseTemplate(template)
+	nodes, err := parseTemplate(spec)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return evalNodes(nodes, vars)
+	for _, n := range nodes {
+		if e, ok := n.(exprNode); ok {
+			if err := resolveBody(e.body); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return &k8sTemplate{nodes: nodes}, nil
+}
+
+// Render evaluates and expands the template into a schema URL.
+func (t *k8sTemplate) Render(group, version, kind string) string {
+	if version == "" || kind == "" {
+		return ""
+	}
+	var b strings.Builder
+	renderNodes(&b, t.nodes, k8sVars(group, version, kind))
+	return b.String()
 }
 
 // node is a parsed template fragment: either literal text or a {expression}.
@@ -84,6 +84,7 @@ type exprBody struct {
 	expr    expression
 	operand term
 	word    term
+	op      operator
 }
 
 // termKind discriminates a term: operand references a var by name, word is literal.
@@ -109,6 +110,75 @@ const (
 	operatorUpper
 	operatorLower
 )
+
+func k8sVars(group, version, kind string) map[string]string {
+	groupFirst, _, _ := strings.Cut(group, ".")
+	groupSeg := ""
+	if group != "" {
+		groupSeg = group + "/"
+	}
+	groupFirstSeg := ""
+	if groupFirst != "" {
+		groupFirstSeg = groupFirst + "-"
+	}
+	return map[string]string{
+		"group":         group,
+		"groupSeg":      groupSeg,
+		"groupFirst":    groupFirst,
+		"groupFirstSeg": groupFirstSeg,
+		"kind":          kind,
+		"kindLower":     strings.ToLower(kind),
+		"version":       version,
+		"versionLower":  strings.ToLower(version),
+	}
+}
+
+var knownK8sVars = func() map[string]struct{} {
+	names := make(map[string]struct{})
+	for name := range k8sVars("", "", "") {
+		names[name] = struct{}{}
+	}
+	return names
+}()
+
+func resolveBody(eb *exprBody) error {
+	if err := resolveTerm(&eb.operand); err != nil {
+		return err
+	}
+	switch eb.expr {
+	case expressionNone:
+		return nil
+	case expressionDefault, expressionAlt:
+		return resolveTerm(&eb.word)
+	case expressionOperator:
+		op := parseOperator(eb.word.raw)
+		if op == operatorNone {
+			return fmt.Errorf("undefined operator %q on {%s}", eb.word.raw, eb.operand.raw)
+		}
+		eb.op = op
+		return nil
+	default:
+		return fmt.Errorf("expression %d not implemented", eb.expr)
+	}
+}
+
+func resolveTerm(t *term) error {
+	if t.nested != nil {
+		return resolveBody(t.nested)
+	}
+	switch t.kind {
+	case termOperand:
+		if _, ok := knownK8sVars[t.raw]; !ok {
+			return fmt.Errorf("unknown placeholder %q", t.raw)
+		}
+		return nil
+	case termWord:
+		t.raw = unescapeWord(t.raw)
+		return nil
+	default:
+		return fmt.Errorf("unknown term kind %d", t.kind)
+	}
+}
 
 func parseTemplate(template string) ([]node, error) {
 	var nodes []node
@@ -210,70 +280,51 @@ func matchBraces(s string, start int) (int, bool) {
 	return 0, false
 }
 
-func evalNodes(nodes []node, vars map[string]string) (string, error) {
-	var b strings.Builder
+func renderNodes(b *strings.Builder, nodes []node, vars map[string]string) {
 	for _, n := range nodes {
 		switch n := n.(type) {
 		case textNode:
 			b.WriteString(n.s)
 		case exprNode:
-			val, err := evalBody(n.body, vars)
-			if err != nil {
-				return "", err
-			}
-			b.WriteString(val)
+			b.WriteString(renderBody(n.body, vars))
 		}
 	}
-	return b.String(), nil
 }
 
-func evalBody(eb *exprBody, vars map[string]string) (string, error) {
+func renderBody(eb *exprBody, vars map[string]string) string {
 	switch eb.expr {
 	case expressionNone:
-		return evalTerm(eb.operand, vars)
+		return renderTerm(eb.operand, vars)
 	case expressionDefault:
-		if val, err := evalTerm(eb.operand, vars); err == nil && val != "" {
-			return val, nil
+		if val := renderTerm(eb.operand, vars); val != "" {
+			return val
 		}
-		return evalTerm(eb.word, vars)
+		return renderTerm(eb.word, vars)
 	case expressionAlt:
-		if val, err := evalTerm(eb.operand, vars); err == nil && val != "" {
-			return evalTerm(eb.word, vars)
+		if renderTerm(eb.operand, vars) != "" {
+			return renderTerm(eb.word, vars)
 		}
-		return "", nil
+		return ""
 	case expressionOperator:
-		val, err := evalTerm(eb.operand, vars)
-		if err != nil {
-			return "", err
+		val := renderTerm(eb.operand, vars)
+		if eb.op == operatorUpper {
+			return strings.ToUpper(val)
 		}
-		switch parseOperator(eb.word.raw) {
-		case operatorUpper:
-			return strings.ToUpper(val), nil
-		case operatorLower:
-			return strings.ToLower(val), nil
-		}
-		return "", fmt.Errorf("undefined operator %q on {%s}", eb.word.raw, eb.operand.raw)
-	default:
-		return "", fmt.Errorf("expression %d not implemented", eb.expr)
+		return strings.ToLower(val)
 	}
+	return ""
 }
 
-func evalTerm(t term, vars map[string]string) (string, error) {
+// renderTerm assumes a resolved term: operand raws are keys of vars (guaranteed
+// by resolveTerm), so a plain index can't miss.
+func renderTerm(t term, vars map[string]string) string {
 	if t.nested != nil {
-		return evalBody(t.nested, vars)
+		return renderBody(t.nested, vars)
 	}
-	switch t.kind {
-	case termOperand:
-		val, ok := vars[t.raw]
-		if !ok {
-			return "", fmt.Errorf("unknown placeholder %q", t.raw)
-		}
-		return val, nil
-	case termWord:
-		return unescapeWord(t.raw), nil
-	default:
-		return "", fmt.Errorf("unknown term kind %d", t.kind)
+	if t.kind == termOperand {
+		return vars[t.raw]
 	}
+	return t.raw
 }
 
 type expression int

--- a/internal/schema/k8s.go
+++ b/internal/schema/k8s.go
@@ -28,6 +28,9 @@ const DefaultK8sSchemaURL = "https://k8s-schemas.home-operations.com/" +
 //
 // Nested expressions: an operand or word may itself be an {expression}, evaluated
 // before the surrounding one, e.g. {{group:-core}@U} yields "CORE" for core.
+//
+// A backslash escapes the next character, dropping the backslash: \{ and \}
+// yield literal braces that don't open or close an expression, \x yields x.
 func BuildK8sURL(template, group, version, kind string) (string, error) {
 	if version == "" || kind == "" {
 		return "", nil
@@ -112,6 +115,13 @@ func parseTemplate(template string) ([]node, error) {
 	var b strings.Builder
 	for i := 0; i < len(template); {
 		switch template[i] {
+		case '\\':
+			if i+1 < len(template) {
+				b.WriteByte(template[i+1])
+				i += 2
+			} else {
+				i++
+			}
 		case '{':
 			if b.Len() > 0 {
 				nodes = append(nodes, textNode{s: b.String()})
@@ -183,6 +193,10 @@ func parseOperator(word string) operator {
 func matchBraces(s string, start int) (int, bool) {
 	depth := 0
 	for i := start; i < len(s); i++ {
+		if s[i] == '\\' {
+			i++
+			continue
+		}
 		switch s[i] {
 		case '{':
 			depth++
@@ -256,7 +270,7 @@ func evalTerm(t term, vars map[string]string) (string, error) {
 		}
 		return val, nil
 	case termWord:
-		return t.raw, nil
+		return unescapeWord(t.raw), nil
 	default:
 		return "", fmt.Errorf("unknown term kind %d", t.kind)
 	}
@@ -285,6 +299,10 @@ func (e expression) separator() string {
 
 func findExpression(s string) (expression, int) {
 	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' {
+			i++
+			continue
+		}
 		if s[i] == '{' {
 			end, ok := matchBraces(s, i)
 			if !ok {
@@ -306,4 +324,22 @@ func findExpression(s string) (expression, int) {
 		}
 	}
 	return expressionNone, -1
+}
+
+func unescapeWord(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' {
+			i++
+			if i < len(s) {
+				b.WriteByte(s[i])
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
 }

--- a/internal/schema/k8s.go
+++ b/internal/schema/k8s.go
@@ -25,6 +25,9 @@ const DefaultK8sSchemaURL = "https://k8s-schemas.home-operations.com/" +
 //	{var:+word}     "word" if var is non-empty, else ""
 //	{var@U}         var but uppercased
 //	{var@L}         var but lowercased
+//
+// Nested expressions: an operand or word may itself be an {expression}, evaluated
+// before the surrounding one, e.g. {{group:-core}@U} yields "CORE" for core.
 func BuildK8sURL(template, group, version, kind string) (string, error) {
 	if version == "" || kind == "" {
 		return "", nil
@@ -76,8 +79,23 @@ func (exprNode) isNode() {}
 // exprBody is an {expression}: a bare operand, or "operand <expr> word".
 type exprBody struct {
 	expr    expression
-	operand string
-	word    string
+	operand term
+	word    term
+}
+
+// termKind discriminates a term: operand references a var by name, word is literal.
+type termKind int
+
+const (
+	termOperand termKind = iota
+	termWord
+)
+
+// term is an operand or word: a var name or literal, or a nested {expression}.
+type term struct {
+	kind   termKind
+	raw    string
+	nested *exprBody
 }
 
 // operator identifies a {var@op} operator.
@@ -103,7 +121,11 @@ func parseTemplate(template string) ([]node, error) {
 			if !ok {
 				return nil, fmt.Errorf("unterminated expression at %d", i)
 			}
-			nodes = append(nodes, exprNode{body: parseBody(template[i+1 : end-1])})
+			body, err := parseBody(template[i+1 : end-1])
+			if err != nil {
+				return nil, fmt.Errorf("%w at %d", err, i)
+			}
+			nodes = append(nodes, exprNode{body: body})
 			i = end
 		case '}':
 			return nil, fmt.Errorf("unexpected '}' at %d", i)
@@ -118,16 +140,34 @@ func parseTemplate(template string) ([]node, error) {
 	return nodes, nil
 }
 
-func parseBody(body string) *exprBody {
+func parseBody(body string) (*exprBody, error) {
 	exp, idx := findExpression(body)
 	eb := &exprBody{expr: exp}
+	var err error
 	if exp == expressionNone {
-		eb.operand = body
-		return eb
+		eb.operand, err = parseTerm(body, termOperand)
+		return eb, err
 	}
-	eb.operand = body[:idx]
-	eb.word = body[idx+len(exp.separator()):]
-	return eb
+	eb.operand, err = parseTerm(body[:idx], termOperand)
+	if err != nil {
+		return nil, err
+	}
+	eb.word, err = parseTerm(body[idx+len(exp.separator()):], termWord)
+	if err != nil {
+		return nil, err
+	}
+	return eb, nil
+}
+
+func parseTerm(s string, kind termKind) (term, error) {
+	if s != "" && s[0] == '{' {
+		if end, ok := matchBraces(s, 0); ok && end == len(s) {
+			nested, err := parseBody(s[1 : len(s)-1])
+			return term{kind: kind, nested: nested}, err
+		}
+		return term{}, fmt.Errorf("unbalanced nested expression %q", s)
+	}
+	return term{kind: kind, raw: s}, nil
 }
 
 func parseOperator(word string) operator {
@@ -176,35 +216,49 @@ func evalNodes(nodes []node, vars map[string]string) (string, error) {
 func evalBody(eb *exprBody, vars map[string]string) (string, error) {
 	switch eb.expr {
 	case expressionNone:
-		val, ok := vars[eb.operand]
-		if !ok {
-			return "", fmt.Errorf("unknown placeholder %q", eb.operand)
-		}
-		return val, nil
+		return evalTerm(eb.operand, vars)
 	case expressionDefault:
-		if val, ok := vars[eb.operand]; ok && val != "" {
+		if val, err := evalTerm(eb.operand, vars); err == nil && val != "" {
 			return val, nil
 		}
-		return eb.word, nil
+		return evalTerm(eb.word, vars)
 	case expressionAlt:
-		if val, ok := vars[eb.operand]; ok && val != "" {
-			return eb.word, nil
+		if val, err := evalTerm(eb.operand, vars); err == nil && val != "" {
+			return evalTerm(eb.word, vars)
 		}
 		return "", nil
 	case expressionOperator:
-		val, ok := vars[eb.operand]
-		if !ok {
-			return "", fmt.Errorf("unknown placeholder %q", eb.operand)
+		val, err := evalTerm(eb.operand, vars)
+		if err != nil {
+			return "", err
 		}
-		switch parseOperator(eb.word) {
+		switch parseOperator(eb.word.raw) {
 		case operatorUpper:
 			return strings.ToUpper(val), nil
 		case operatorLower:
 			return strings.ToLower(val), nil
 		}
-		return "", fmt.Errorf("undefined operator %q on {%s}", eb.word, eb.operand)
+		return "", fmt.Errorf("undefined operator %q on {%s}", eb.word.raw, eb.operand.raw)
 	default:
 		return "", fmt.Errorf("expression %d not implemented", eb.expr)
+	}
+}
+
+func evalTerm(t term, vars map[string]string) (string, error) {
+	if t.nested != nil {
+		return evalBody(t.nested, vars)
+	}
+	switch t.kind {
+	case termOperand:
+		val, ok := vars[t.raw]
+		if !ok {
+			return "", fmt.Errorf("unknown placeholder %q", t.raw)
+		}
+		return val, nil
+	case termWord:
+		return t.raw, nil
+	default:
+		return "", fmt.Errorf("unknown term kind %d", t.kind)
 	}
 }
 

--- a/internal/schema/k8s_test.go
+++ b/internal/schema/k8s_test.go
@@ -5,8 +5,17 @@ import (
 	"testing"
 )
 
+func buildK8sURL(t *testing.T, template, group, version, kind string) string {
+	t.Helper()
+	got, err := BuildK8sURL(template, group, version, kind)
+	if err != nil {
+		t.Fatalf("BuildK8sURL(%q) returned error: %v", template, err)
+	}
+	return got
+}
+
 func TestBuildK8sURL_DefaultPointsAtHomeOperations(t *testing.T) {
-	got := BuildK8sURL("", "apps", "v1", "Deployment")
+	got := buildK8sURL(t, "", "apps", "v1", "Deployment")
 	want := "https://k8s-schemas.home-operations.com/apps/deployment_v1.json"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -14,7 +23,7 @@ func TestBuildK8sURL_DefaultPointsAtHomeOperations(t *testing.T) {
 }
 
 func TestBuildK8sURL_DefaultCoreResource(t *testing.T) {
-	got := BuildK8sURL("", "", "v1", "Pod")
+	got := buildK8sURL(t, "", "", "v1", "Pod")
 	want := "https://k8s-schemas.home-operations.com/core/pod_v1.json"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -23,7 +32,7 @@ func TestBuildK8sURL_DefaultCoreResource(t *testing.T) {
 
 func TestBuildK8sURL_TemplatePlaceholders(t *testing.T) {
 	tmpl := "https://schemas.example.com/{group}{group:+/}{kind@L}_{version@L}.json"
-	got := BuildK8sURL(tmpl, "helm.toolkit.fluxcd.io", "v2", "HelmRelease")
+	got := buildK8sURL(t, tmpl, "helm.toolkit.fluxcd.io", "v2", "HelmRelease")
 	want := "https://schemas.example.com/helm.toolkit.fluxcd.io/helmrelease_v2.json"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -32,26 +41,26 @@ func TestBuildK8sURL_TemplatePlaceholders(t *testing.T) {
 
 func TestBuildK8sURL_YannhLayoutViaTemplate(t *testing.T) {
 	tmpl := "https://yannh.example/{kind@L}-{groupFirst}{groupFirst:+-}{version@L}.json"
-	if got := BuildK8sURL(tmpl, "", "v1", "Pod"); got != "https://yannh.example/pod-v1.json" {
+	if got := buildK8sURL(t, tmpl, "", "v1", "Pod"); got != "https://yannh.example/pod-v1.json" {
 		t.Errorf("core: got %q", got)
 	}
-	if got := BuildK8sURL(tmpl, "apps", "v1", "Deployment"); got != "https://yannh.example/deployment-apps-v1.json" {
+	if got := buildK8sURL(t, tmpl, "apps", "v1", "Deployment"); got != "https://yannh.example/deployment-apps-v1.json" {
 		t.Errorf("grouped: got %q", got)
 	}
 }
 
 func TestBuildK8sURL_EmptyWhenMissingFields(t *testing.T) {
-	if got := BuildK8sURL("", "apps", "", "Deployment"); got != "" {
+	if got := buildK8sURL(t, "", "apps", "", "Deployment"); got != "" {
 		t.Errorf("missing version should yield empty, got %q", got)
 	}
-	if got := BuildK8sURL("", "apps", "v1", ""); got != "" {
+	if got := buildK8sURL(t, "", "apps", "v1", ""); got != "" {
 		t.Errorf("missing kind should yield empty, got %q", got)
 	}
 }
 
 func TestBuildK8sURL_AllPlaceholdersResolve(t *testing.T) {
 	tmpl := "{group}|{groupSeg}|{groupFirst}|{groupFirstSeg}|{kind}|{kindLower}|{version}|{versionLower}"
-	got := BuildK8sURL(tmpl, "apps.k8s.io", "v1beta1", "Deployment")
+	got := buildK8sURL(t, tmpl, "apps.k8s.io", "v1beta1", "Deployment")
 	if strings.Contains(got, "{") || strings.Contains(got, "}") {
 		t.Errorf("unsubstituted placeholder leaked: %q", got)
 	}
@@ -71,7 +80,7 @@ func TestBuildK8sURL_ExprDefaultOnEmpty(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := BuildK8sURL(tc.tmpl, tc.group, "v1", "Resource"); got != tc.want {
+			if got := buildK8sURL(t, tc.tmpl, tc.group, "v1", "Resource"); got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
@@ -90,7 +99,7 @@ func TestBuildK8sURL_ExprAltOnNonEmpty(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := BuildK8sURL(tc.tmpl, tc.group, "v1", "Resource"); got != tc.want {
+			if got := buildK8sURL(t, tc.tmpl, tc.group, "v1", "Resource"); got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
@@ -98,13 +107,13 @@ func TestBuildK8sURL_ExprAltOnNonEmpty(t *testing.T) {
 }
 
 func TestBuildK8sURL_ExprSimpleSubstitution(t *testing.T) {
-	if got := BuildK8sURL("{group}", "", "v1", "Namespace"); got != "" {
+	if got := buildK8sURL(t, "{group}", "", "v1", "Namespace"); got != "" {
 		t.Errorf("core: got %q", got)
 	}
-	if got := BuildK8sURL("{group}", "apps", "v1", "Resource"); got != "apps" {
+	if got := buildK8sURL(t, "{group}", "apps", "v1", "Resource"); got != "apps" {
 		t.Errorf("got %q, want apps", got)
 	}
-	if got := BuildK8sURL("{kind}", "apps", "v1", "Deployment"); got != "Deployment" {
+	if got := buildK8sURL(t, "{kind}", "apps", "v1", "Deployment"); got != "Deployment" {
 		t.Errorf("got %q, want Deployment", got)
 	}
 }
@@ -112,21 +121,29 @@ func TestBuildK8sURL_ExprSimpleSubstitution(t *testing.T) {
 func TestBuildK8sURL_ExprComposeGroupSeg(t *testing.T) {
 	tmpl := "{group:-core}/{kind}_{version}.json"
 
-	if got := BuildK8sURL(tmpl, "", "v1", "Namespace"); got != "core/Namespace_v1.json" {
+	if got := buildK8sURL(t, tmpl, "", "v1", "Namespace"); got != "core/Namespace_v1.json" {
 		t.Errorf("core: got %q", got)
 	}
-	if got := BuildK8sURL(tmpl, "apps", "v1", "Deployment"); got != "apps/Deployment_v1.json" {
+	if got := buildK8sURL(t, tmpl, "apps", "v1", "Deployment"); got != "apps/Deployment_v1.json" {
 		t.Errorf("grouped: got %q", got)
 	}
-	if got := BuildK8sURL(tmpl, "rbac.authorization.k8s.io", "v1", "ClusterRole"); got != "rbac.authorization.k8s.io/ClusterRole_v1.json" {
+	if got := buildK8sURL(t, tmpl, "rbac.authorization.k8s.io", "v1", "ClusterRole"); got != "rbac.authorization.k8s.io/ClusterRole_v1.json" {
 		t.Errorf("dotted group: got %q", got)
 	}
 }
 
-func TestBuildK8sURL_ExprPreservesUnknownPlaceholders(t *testing.T) {
-	tmpl := "{unknown}/{group}"
-	if got := BuildK8sURL(tmpl, "apps", "v1", "Deployment"); got != "{unknown}/apps" {
-		t.Errorf("got %q", got)
+func TestBuildK8sURL_UnknownPlaceholderErrors(t *testing.T) {
+	tmpls := []string{
+		"{unknown}",
+		"{unknown}/{group}",
+		"{unknown@x}",
+	}
+	for _, tmpl := range tmpls {
+		t.Run(tmpl, func(t *testing.T) {
+			if got, err := BuildK8sURL(tmpl, "apps", "v1", "Deployment"); err == nil {
+				t.Errorf("expected error for %q, got %q", tmpl, got)
+			}
+		})
 	}
 }
 
@@ -173,7 +190,7 @@ func TestBuildK8sURL_ExprUppercaseOperator(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := BuildK8sURL(tc.tmpl, tc.group, tc.version, tc.kind); got != tc.want {
+			if got := buildK8sURL(t, tc.tmpl, tc.group, tc.version, tc.kind); got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
@@ -223,7 +240,7 @@ func TestBuildK8sURL_ExprLowercaseOperator(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := BuildK8sURL(tc.tmpl, tc.group, tc.version, tc.kind); got != tc.want {
+			if got := buildK8sURL(t, tc.tmpl, tc.group, tc.version, tc.kind); got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
@@ -231,31 +248,53 @@ func TestBuildK8sURL_ExprLowercaseOperator(t *testing.T) {
 }
 
 func TestBuildK8sURL_ExprUndefinedOperator(t *testing.T) {
+	tmpls := []string{
+		"{group@xyz}",
+		"{kind@}",
+	}
+	for _, tmpl := range tmpls {
+		t.Run(tmpl, func(t *testing.T) {
+			if got, err := BuildK8sURL(tmpl, "apps", "v1", "Deployment"); err == nil {
+				t.Errorf("expected error for %q, got %q", tmpl, got)
+			}
+		})
+	}
+}
+
+func TestBuildK8sURL_UnbalancedBraces(t *testing.T) {
 	tests := []struct {
 		name string
 		tmpl string
-		want string
 	}{
 		{
-			name: "known var with unknown operator returns var value",
-			tmpl: "{group@x}",
-			want: "apps",
+			name: "unterminated expression",
+			tmpl: "{group:-core",
 		},
 		{
-			name: "unknown var with unknown operator preserved",
-			tmpl: "{unknown@x}",
-			want: "{unknown@x}",
+			name: "unterminated expression in url",
+			tmpl: "https://schemas.example.com/{group:-core",
 		},
 		{
-			name: "empty operator returns var value",
-			tmpl: "{kind@}",
-			want: "Deployment",
+			name: "extra opening brace",
+			tmpl: "{{group:-core}",
+		},
+		{
+			name: "extra closing brace",
+			tmpl: "{group:-core}}",
+		},
+		{
+			name: "lone opening brace",
+			tmpl: "foo{bar",
+		},
+		{
+			name: "lone closing brace",
+			tmpl: "foo}bar",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := BuildK8sURL(tc.tmpl, "apps", "v1", "Deployment"); got != tc.want {
-				t.Errorf("got %q, want %q", got, tc.want)
+			if got, err := BuildK8sURL(tc.tmpl, "", "v1", "Resource"); err == nil {
+				t.Errorf("expected error for %q, got %q", tc.tmpl, got)
 			}
 		})
 	}
@@ -319,7 +358,7 @@ func TestBuildK8sURL_LegacyLowercaseVars(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := BuildK8sURL(tc.tmpl, tc.group, tc.version, tc.kind); got != tc.want {
+			if got := buildK8sURL(t, tc.tmpl, tc.group, tc.version, tc.kind); got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
@@ -327,8 +366,8 @@ func TestBuildK8sURL_LegacyLowercaseVars(t *testing.T) {
 }
 
 func TestBuildK8sURL_LegacyVarsMatchOperators(t *testing.T) {
-	legacy := BuildK8sURL("{kindLower}_{versionLower}", "apps", "V1Beta1", "Deployment")
-	operators := BuildK8sURL("{kind@L}_{version@L}", "apps", "V1Beta1", "Deployment")
+	legacy := buildK8sURL(t, "{kindLower}_{versionLower}", "apps", "V1Beta1", "Deployment")
+	operators := buildK8sURL(t, "{kind@L}_{version@L}", "apps", "V1Beta1", "Deployment")
 	if legacy != operators {
 		t.Errorf("legacy %q != operator form %q", legacy, operators)
 	}
@@ -378,7 +417,7 @@ func TestBuildK8sURL_LegacySegVars(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := BuildK8sURL(tc.tmpl, tc.group, "v1", "Resource"); got != tc.want {
+			if got := buildK8sURL(t, tc.tmpl, tc.group, "v1", "Resource"); got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
@@ -387,10 +426,10 @@ func TestBuildK8sURL_LegacySegVars(t *testing.T) {
 
 func TestBuildK8sURL_LegacySegVarsMatchComposition(t *testing.T) {
 	for _, group := range []string{"", "apps", "rbac.authorization.k8s.io"} {
-		if got, want := BuildK8sURL("{groupSeg}", group, "v1", "Resource"), BuildK8sURL("{group}{group:+/}", group, "v1", "Resource"); got != want {
+		if got, want := buildK8sURL(t, "{groupSeg}", group, "v1", "Resource"), buildK8sURL(t, "{group}{group:+/}", group, "v1", "Resource"); got != want {
 			t.Errorf("group %q: {groupSeg} %q != {group}{group:+/} %q", group, got, want)
 		}
-		if got, want := BuildK8sURL("{groupFirstSeg}", group, "v1", "Resource"), BuildK8sURL("{groupFirst}{groupFirst:+-}", group, "v1", "Resource"); got != want {
+		if got, want := buildK8sURL(t, "{groupFirstSeg}", group, "v1", "Resource"), buildK8sURL(t, "{groupFirst}{groupFirst:+-}", group, "v1", "Resource"); got != want {
 			t.Errorf("group %q: {groupFirstSeg} %q != {groupFirst}{groupFirst:+-} %q", group, got, want)
 		}
 	}

--- a/internal/schema/k8s_test.go
+++ b/internal/schema/k8s_test.go
@@ -7,14 +7,14 @@ import (
 
 func buildK8sURL(t *testing.T, template, group, version, kind string) string {
 	t.Helper()
-	got, err := BuildK8sURL(template, group, version, kind)
+	parsed, err := parseK8sTemplate(template)
 	if err != nil {
-		t.Fatalf("BuildK8sURL(%q) returned error: %v", template, err)
+		t.Fatalf("ParseK8sTemplate(%q) returned error: %v", template, err)
 	}
-	return got
+	return parsed.Render(group, version, kind)
 }
 
-func TestBuildK8sURL_DefaultPointsAtHomeOperations(t *testing.T) {
+func TestRenderK8sURL_DefaultPointsAtHomeOperations(t *testing.T) {
 	got := buildK8sURL(t, "", "apps", "v1", "Deployment")
 	want := "https://k8s-schemas.home-operations.com/apps/deployment_v1.json"
 	if got != want {
@@ -22,7 +22,7 @@ func TestBuildK8sURL_DefaultPointsAtHomeOperations(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_DefaultCoreResource(t *testing.T) {
+func TestRenderK8sURL_DefaultCoreResource(t *testing.T) {
 	got := buildK8sURL(t, "", "", "v1", "Pod")
 	want := "https://k8s-schemas.home-operations.com/core/pod_v1.json"
 	if got != want {
@@ -30,7 +30,7 @@ func TestBuildK8sURL_DefaultCoreResource(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_TemplatePlaceholders(t *testing.T) {
+func TestRenderK8sURL_TemplatePlaceholders(t *testing.T) {
 	tmpl := "https://schemas.example.com/{group}{group:+/}{kind@L}_{version@L}.json"
 	got := buildK8sURL(t, tmpl, "helm.toolkit.fluxcd.io", "v2", "HelmRelease")
 	want := "https://schemas.example.com/helm.toolkit.fluxcd.io/helmrelease_v2.json"
@@ -39,7 +39,7 @@ func TestBuildK8sURL_TemplatePlaceholders(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_YannhLayoutViaTemplate(t *testing.T) {
+func TestRenderK8sURL_YannhLayoutViaTemplate(t *testing.T) {
 	tmpl := "https://yannh.example/{kind@L}-{groupFirst}{groupFirst:+-}{version@L}.json"
 	if got := buildK8sURL(t, tmpl, "", "v1", "Pod"); got != "https://yannh.example/pod-v1.json" {
 		t.Errorf("core: got %q", got)
@@ -49,7 +49,7 @@ func TestBuildK8sURL_YannhLayoutViaTemplate(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_EmptyWhenMissingFields(t *testing.T) {
+func TestRenderK8sURL_EmptyWhenMissingFields(t *testing.T) {
 	if got := buildK8sURL(t, "", "apps", "", "Deployment"); got != "" {
 		t.Errorf("missing version should yield empty, got %q", got)
 	}
@@ -58,7 +58,7 @@ func TestBuildK8sURL_EmptyWhenMissingFields(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_AllPlaceholdersResolve(t *testing.T) {
+func TestRenderK8sURL_AllPlaceholdersResolve(t *testing.T) {
 	tmpl := "{group}|{groupSeg}|{groupFirst}|{groupFirstSeg}|{kind}|{kindLower}|{version}|{versionLower}"
 	got := buildK8sURL(t, tmpl, "apps.k8s.io", "v1beta1", "Deployment")
 	if strings.Contains(got, "{") || strings.Contains(got, "}") {
@@ -66,7 +66,7 @@ func TestBuildK8sURL_AllPlaceholdersResolve(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_ExprDefaultOnEmpty(t *testing.T) {
+func TestRenderK8sURL_ExprDefaultOnEmpty(t *testing.T) {
 	tests := []struct {
 		name  string
 		group string
@@ -87,7 +87,7 @@ func TestBuildK8sURL_ExprDefaultOnEmpty(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_ExprAltOnNonEmpty(t *testing.T) {
+func TestRenderK8sURL_ExprAltOnNonEmpty(t *testing.T) {
 	tests := []struct {
 		name  string
 		group string
@@ -106,7 +106,7 @@ func TestBuildK8sURL_ExprAltOnNonEmpty(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_ExprSimpleSubstitution(t *testing.T) {
+func TestRenderK8sURL_ExprSimpleSubstitution(t *testing.T) {
 	if got := buildK8sURL(t, "{group}", "", "v1", "Namespace"); got != "" {
 		t.Errorf("core: got %q", got)
 	}
@@ -118,7 +118,7 @@ func TestBuildK8sURL_ExprSimpleSubstitution(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_ExprComposeGroupSeg(t *testing.T) {
+func TestRenderK8sURL_ExprComposeGroupSeg(t *testing.T) {
 	tmpl := "{group:-core}/{kind}_{version}.json"
 
 	if got := buildK8sURL(t, tmpl, "", "v1", "Namespace"); got != "core/Namespace_v1.json" {
@@ -132,7 +132,7 @@ func TestBuildK8sURL_ExprComposeGroupSeg(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_UnknownPlaceholderErrors(t *testing.T) {
+func TestParseK8sTemplate_UnknownPlaceholder(t *testing.T) {
 	tmpls := []string{
 		"{unknown}",
 		"{unknown}/{group}",
@@ -140,14 +140,14 @@ func TestBuildK8sURL_UnknownPlaceholderErrors(t *testing.T) {
 	}
 	for _, tmpl := range tmpls {
 		t.Run(tmpl, func(t *testing.T) {
-			if got, err := BuildK8sURL(tmpl, "apps", "v1", "Deployment"); err == nil {
-				t.Errorf("expected error for %q, got %q", tmpl, got)
+			if _, err := parseK8sTemplate(tmpl); err == nil {
+				t.Errorf("expected error for %q", tmpl)
 			}
 		})
 	}
 }
 
-func TestBuildK8sURL_ExprUppercaseOperator(t *testing.T) {
+func TestRenderK8sURL_ExprUppercaseOperator(t *testing.T) {
 	tests := []struct {
 		name    string
 		tmpl    string
@@ -197,7 +197,7 @@ func TestBuildK8sURL_ExprUppercaseOperator(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_ExprLowercaseOperator(t *testing.T) {
+func TestRenderK8sURL_ExprLowercaseOperator(t *testing.T) {
 	tests := []struct {
 		name    string
 		tmpl    string
@@ -247,21 +247,21 @@ func TestBuildK8sURL_ExprLowercaseOperator(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_ExprUndefinedOperator(t *testing.T) {
+func TestParseK8sTemplate_UndefinedOperator(t *testing.T) {
 	tmpls := []string{
 		"{group@xyz}",
 		"{kind@}",
 	}
 	for _, tmpl := range tmpls {
 		t.Run(tmpl, func(t *testing.T) {
-			if got, err := BuildK8sURL(tmpl, "apps", "v1", "Deployment"); err == nil {
-				t.Errorf("expected error for %q, got %q", tmpl, got)
+			if _, err := parseK8sTemplate(tmpl); err == nil {
+				t.Errorf("expected error for %q", tmpl)
 			}
 		})
 	}
 }
 
-func TestBuildK8sURL_NestedExpressions(t *testing.T) {
+func TestRenderK8sURL_NestedExpressions(t *testing.T) {
 	tests := []struct {
 		name  string
 		tmpl  string
@@ -356,7 +356,7 @@ func TestBuildK8sURL_NestedExpressions(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_Escaping(t *testing.T) {
+func TestRenderK8sURL_Escaping(t *testing.T) {
 	tests := []struct {
 		name  string
 		tmpl  string
@@ -439,7 +439,42 @@ func TestBuildK8sURL_Escaping(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_UnbalancedBraces(t *testing.T) {
+func TestParseK8sTemplate_NestedInSkippedBranch(t *testing.T) {
+	tmpls := []string{
+		"{group:-{kind@xyz}}",
+		"{group:+{version@q}}",
+		"{group:+{nope}}",
+		"{{group@q}:-core}",
+		"{kind@{group:-x}}",
+	}
+	for _, tmpl := range tmpls {
+		t.Run(tmpl, func(t *testing.T) {
+			if _, err := parseK8sTemplate(tmpl); err == nil {
+				t.Errorf("expected error for %q", tmpl)
+			}
+		})
+	}
+}
+
+func TestParseK8sTemplate_ValidTemplates(t *testing.T) {
+	tmpls := []string{
+		"{group:-core}/{kind@L}_{version@L}.json",
+		"{group}{group:+/}{kind@L}_{version@L}.json",
+		"https://example.com/{kindLower}.json",
+		"{group:-{kind@U}}",
+		"{{group:-core}@U}",
+		`a\{group\}b`,
+	}
+	for _, tmpl := range tmpls {
+		t.Run(tmpl, func(t *testing.T) {
+			if _, err := parseK8sTemplate(tmpl); err != nil {
+				t.Errorf("unexpected error for %q: %v", tmpl, err)
+			}
+		})
+	}
+}
+
+func TestParseK8sTemplate_UnbalancedBraces(t *testing.T) {
 	tests := []struct {
 		name string
 		tmpl string
@@ -471,14 +506,14 @@ func TestBuildK8sURL_UnbalancedBraces(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got, err := BuildK8sURL(tc.tmpl, "", "v1", "Resource"); err == nil {
-				t.Errorf("expected error for %q, got %q", tc.tmpl, got)
+			if _, err := parseK8sTemplate(tc.tmpl); err == nil {
+				t.Errorf("expected error for %q", tc.tmpl)
 			}
 		})
 	}
 }
 
-func TestBuildK8sURL_LegacyLowercaseVars(t *testing.T) {
+func TestRenderK8sURL_LegacyLowercaseVars(t *testing.T) {
 	tests := []struct {
 		name    string
 		tmpl    string
@@ -543,7 +578,7 @@ func TestBuildK8sURL_LegacyLowercaseVars(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_LegacyVarsMatchOperators(t *testing.T) {
+func TestRenderK8sURL_LegacyVarsMatchOperators(t *testing.T) {
 	legacy := buildK8sURL(t, "{kindLower}_{versionLower}", "apps", "V1Beta1", "Deployment")
 	operators := buildK8sURL(t, "{kind@L}_{version@L}", "apps", "V1Beta1", "Deployment")
 	if legacy != operators {
@@ -551,7 +586,7 @@ func TestBuildK8sURL_LegacyVarsMatchOperators(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_LegacySegVars(t *testing.T) {
+func TestRenderK8sURL_LegacySegVars(t *testing.T) {
 	tests := []struct {
 		name  string
 		tmpl  string
@@ -602,7 +637,7 @@ func TestBuildK8sURL_LegacySegVars(t *testing.T) {
 	}
 }
 
-func TestBuildK8sURL_LegacySegVarsMatchComposition(t *testing.T) {
+func TestRenderK8sURL_LegacySegVarsMatchComposition(t *testing.T) {
 	for _, group := range []string{"", "apps", "rbac.authorization.k8s.io"} {
 		if got, want := buildK8sURL(t, "{groupSeg}", group, "v1", "Resource"), buildK8sURL(t, "{group}{group:+/}", group, "v1", "Resource"); got != want {
 			t.Errorf("group %q: {groupSeg} %q != {group}{group:+/} %q", group, got, want)

--- a/internal/schema/k8s_test.go
+++ b/internal/schema/k8s_test.go
@@ -356,6 +356,89 @@ func TestBuildK8sURL_NestedExpressions(t *testing.T) {
 	}
 }
 
+func TestBuildK8sURL_Escaping(t *testing.T) {
+	tests := []struct {
+		name  string
+		tmpl  string
+		group string
+		want  string
+	}{
+		{
+			name:  "both braces escaped at top level",
+			tmpl:  `\{group\}`,
+			group: "apps",
+			want:  "{group}",
+		},
+		{
+			name:  "escaped open brace",
+			tmpl:  `a\{b`,
+			group: "apps",
+			want:  "a{b",
+		},
+		{
+			name:  "escaped close brace",
+			tmpl:  `a\}b`,
+			group: "apps",
+			want:  "a}b",
+		},
+		{
+			name:  "escaped braces in url",
+			tmpl:  `https://example.com/\{kind\}`,
+			group: "apps",
+			want:  "https://example.com/{kind}",
+		},
+		{
+			name:  "escaped braces next to expression",
+			tmpl:  `\{group\}/{kind@L}`,
+			group: "apps",
+			want:  "{group}/deployment",
+		},
+		{
+			name:  "escaped close brace in fallback word",
+			tmpl:  `{group:-a\}b}`,
+			group: "",
+			want:  "a}b",
+		},
+		{
+			name:  "escaped open brace in fallback word",
+			tmpl:  `{group:-a\{b}`,
+			group: "",
+			want:  "a{b",
+		},
+		{
+			name:  "escaped backslash in fallback word",
+			tmpl:  `{group:-a\@b}`,
+			group: "",
+			want:  "a@b",
+		},
+		{
+			name:  "backslash before non-brace drops backslash",
+			tmpl:  `a\b`,
+			group: "apps",
+			want:  "ab",
+		},
+		{
+			name:  "double backslash yields single",
+			tmpl:  `a\\b`,
+			group: "apps",
+			want:  `a\b`,
+		},
+		{
+			name:  "trailing backslash dropped",
+			tmpl:  `a\`,
+			group: "apps",
+			want:  "a",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := buildK8sURL(t, tc.tmpl, tc.group, "v1", "Deployment"); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuildK8sURL_UnbalancedBraces(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/schema/k8s_test.go
+++ b/internal/schema/k8s_test.go
@@ -261,6 +261,101 @@ func TestBuildK8sURL_ExprUndefinedOperator(t *testing.T) {
 	}
 }
 
+func TestBuildK8sURL_NestedExpressions(t *testing.T) {
+	tests := []struct {
+		name  string
+		tmpl  string
+		group string
+		want  string
+	}{
+		{
+			name:  "empty group uppercased fallback",
+			tmpl:  "{{group:-core}@U}",
+			group: "",
+			want:  "CORE",
+		},
+		{
+			name:  "grouped group uppercased",
+			tmpl:  "{{group:-core}@U}",
+			group: "apps",
+			want:  "APPS",
+		},
+		{
+			name:  "empty group lowercased fallback",
+			tmpl:  "{{group:-Core}@L}",
+			group: "",
+			want:  "core",
+		},
+		{
+			name:  "nested operand lowercased then defaulted",
+			tmpl:  "{{group@L}:-core}",
+			group: "APPS",
+			want:  "apps",
+		},
+		{
+			name:  "nested operand lowercased empty uses fallback",
+			tmpl:  "{{group@L}:-Core}",
+			group: "",
+			want:  "Core",
+		},
+		{
+			name:  "nested expression in fallback word",
+			tmpl:  "{group:-{kind@U}}",
+			group: "",
+			want:  "DEPLOYMENT",
+		},
+		{
+			name:  "nested word only when value empty",
+			tmpl:  "{group:-{kind@L}}",
+			group: "apps",
+			want:  "apps",
+		},
+		{
+			name:  "nested in url",
+			tmpl:  "https://schemas.example.com/{{group:-core}@U}/{kind@L}.json",
+			group: "",
+			want:  "https://schemas.example.com/CORE/deployment.json",
+		},
+		{
+			name:  "depth 3 lowercased fallback",
+			tmpl:  "{{{group:-core}@U}@L}",
+			group: "",
+			want:  "core",
+		},
+		{
+			name:  "depth 3 lowercased value",
+			tmpl:  "{{{group:-core}@U}@L}",
+			group: "apps",
+			want:  "apps",
+		},
+		{
+			name:  "depth 4 uppercased fallback",
+			tmpl:  "{{{{group:-core}@U}@L}@U}",
+			group: "",
+			want:  "CORE",
+		},
+		{
+			name:  "depth 4 uppercased value",
+			tmpl:  "{{{{group:-core}@U}@L}@U}",
+			group: "apps",
+			want:  "APPS",
+		},
+		{
+			name:  "operator outside braces is literal",
+			tmpl:  "{group:-core}@U",
+			group: "",
+			want:  "core@U",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := buildK8sURL(t, tc.tmpl, tc.group, "v1", "Deployment"); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuildK8sURL_UnbalancedBraces(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/schema/resolver.go
+++ b/internal/schema/resolver.go
@@ -19,6 +19,7 @@ type Resolver struct {
 	mu         sync.RWMutex
 	settings   config.Settings
 	catalog    *Catalog
+	k8sTmpl    *k8sTemplate
 	reloadHook func()
 }
 
@@ -38,8 +39,11 @@ func (r *Resolver) SetReloadHook(fn func()) {
 }
 
 func (r *Resolver) SetSettings(s config.Settings) {
+	k8sTmpl := k8sTemplateFor(s)
+
 	r.mu.Lock()
 	r.settings = s
+	r.k8sTmpl = k8sTmpl
 	var toLoad *Catalog
 	if s.CatalogEnabled() {
 		if r.catalog == nil || r.catalog.URL != effectiveCatalogURL(s) {
@@ -55,6 +59,27 @@ func (r *Resolver) SetSettings(s config.Settings) {
 	if toLoad != nil {
 		toLoad.Load(hook)
 	}
+}
+
+func k8sTemplateFor(s config.Settings) *k8sTemplate {
+	if !s.KubernetesEnabled() {
+		return nil
+	}
+	spec := ""
+	if s.Kubernetes != nil {
+		spec = s.Kubernetes.SchemaURL
+	}
+	tmpl, err := parseK8sTemplate(spec)
+	if err != nil {
+		slog.Warn(
+			"schema: invalid kubernetes.schemaUrl template",
+			"template",
+			spec,
+			"error",
+			err)
+		return nil
+	}
+	return tmpl
 }
 
 func effectiveCatalogURL(s config.Settings) string {
@@ -167,24 +192,10 @@ func (r *Resolver) K8sURLForNode(body ast.Node) string {
 
 func (r *Resolver) K8sURL(gvk GVK) string {
 	r.mu.RLock()
-	enabled := r.settings.KubernetesEnabled()
-	tmpl := ""
-	if r.settings.Kubernetes != nil {
-		tmpl = r.settings.Kubernetes.SchemaURL
-	}
+	tmpl := r.k8sTmpl
 	r.mu.RUnlock()
-	if !enabled {
+	if tmpl == nil {
 		return ""
 	}
-	url, err := BuildK8sURL(tmpl, gvk.Group, gvk.Version, gvk.Kind)
-	if err != nil {
-		slog.Warn(
-			"invalid kubernetes.schemaUrl template",
-			"template",
-			tmpl,
-			"error",
-			err)
-		return ""
-	}
-	return url
+	return tmpl.Render(gvk.Group, gvk.Version, gvk.Kind)
 }

--- a/internal/schema/resolver.go
+++ b/internal/schema/resolver.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"log/slog"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -175,5 +176,15 @@ func (r *Resolver) K8sURL(gvk GVK) string {
 	if !enabled {
 		return ""
 	}
-	return BuildK8sURL(tmpl, gvk.Group, gvk.Version, gvk.Kind)
+	url, err := BuildK8sURL(tmpl, gvk.Group, gvk.Version, gvk.Kind)
+	if err != nil {
+		slog.Warn(
+			"invalid kubernetes.schemaUrl template",
+			"template",
+			tmpl,
+			"error",
+			err)
+		return ""
+	}
+	return url
 }

--- a/internal/schema/resolver_test.go
+++ b/internal/schema/resolver_test.go
@@ -52,6 +52,27 @@ func TestResolver_K8sURLGatedByEnabled(t *testing.T) {
 	}
 }
 
+func TestResolver_InvalidK8sTemplateDisablesURLs(t *testing.T) {
+	gvk := GVK{Group: "apps", Version: "v1", Kind: "Deployment"}
+	r := NewResolver()
+
+	r.SetSettings(config.Settings{
+		Kubernetes: &config.KubernetesSettings{SchemaURL: "{nope}"},
+	})
+	if got := r.K8sURL(gvk); got != "" {
+		t.Errorf("expected empty for invalid template, got %q", got)
+	}
+
+	r.SetSettings(config.Settings{
+		Kubernetes: &config.KubernetesSettings{
+			SchemaURL: "{group:-core}/{kind@L}_{version@L}.json",
+		},
+	})
+	if got := r.K8sURL(gvk); got == "" {
+		t.Errorf("expected URLs after replacing the broken template, got empty")
+	}
+}
+
 func TestMatchSettings_DeterministicMostSpecific(t *testing.T) {
 	schemas := map[string][]string{
 		"./a.json": {"**/*.yaml"},

--- a/internal/schema/walk.go
+++ b/internal/schema/walk.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/home-operations/yayamlls/internal/yamlast"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
@@ -19,18 +20,13 @@ func Resolve(root *jsonschema.Schema, ptr string) *jsonschema.Schema {
 		return cur
 	}
 	for seg := range strings.SplitSeq(strings.TrimPrefix(ptr, "/"), "/") {
-		next := step(cur, unescape(seg))
+		next := step(cur, yamlast.UnescapePointerSegment(seg))
 		if next == nil {
 			return nil
 		}
 		cur = follow(next)
 	}
 	return cur
-}
-
-func unescape(s string) string {
-	s = strings.ReplaceAll(s, "~1", "/")
-	return strings.ReplaceAll(s, "~0", "~")
 }
 
 // follow unwraps a $ref chain, but stops at a node that carries its own


### PR DESCRIPTION
## Overview

Adds nested expression support for schema URL templates, allowing expressions to be composed. For example: `{{group:-core}@L}` applies a default and then lowercases the result.

Additionally:

- Replaces the regexp-based template engine from #141 with a hand-rolled parser that is more robust and handles nested braces correctly.

- Adds backslash escaping: `\{` and `\}` produce literal braces that don't open or close an expression. Other escape sequences are simply stripped of the backslash: `\n` yields `n`.

- Validates the template once at settings load; an invalid template warns once at startup rather than failing at GVK resolution. The warning currently goes to slog (stdout), but it could be changed to a `window/showMessage` notification in a future PR.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: Yes. Draft, review, and test iteration are AI-assisted.