### PR TITLE
chore(go): bump toolchain and go directive to 1.27

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,6 +1,6 @@
 [tools]
 actionlint = "1.7.12"
-go = "1.26.6"
+go = "1.27.0"
 "go:golang.org/x/vuln/cmd/govulncheck" = "v1.7.0"
 golangci-lint = "2.13.2"
 lefthook = "2.1.11"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -23,20 +23,20 @@ url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/3849248
 provenance = "github-attestations"
 
 [[tools.go]]
-version = "1.26.6"
+version = "1.27.0"
 backend = "core:go"
 
 [tools.go."platforms.linux-arm64"]
-checksum = "sha256:d0507e9e9d7fe012aae570108cbd76c15de879e17130ab8cb90d4d7445cb1f2e"
-url = "https://dl.google.com/go/go1.26.6.linux-arm64.tar.gz"
+checksum = "sha256:51798d2c42d0e1c6ed7fd9f48728b4193abac9e8aad6dbac2fe96a81f5909bda"
+url = "https://dl.google.com/go/go1.27.0.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-x64"]
-checksum = "sha256:708effb774be8237570d0add163225abbdfaf4fca28b2611df167beba4feef89"
-url = "https://dl.google.com/go/go1.26.6.linux-amd64.tar.gz"
+checksum = "sha256:675c26c449cbb18fc24b74650de1eabbae6e16f64326fd85a283fb3b58280685"
+url = "https://dl.google.com/go/go1.27.0.linux-amd64.tar.gz"
 
 [tools.go."platforms.macos-arm64"]
-checksum = "sha256:2dc95ce4675829f2df0e86b28bcef3283635902062a5f0580ca659bf570f3204"
-url = "https://dl.google.com/go/go1.26.6.darwin-arm64.tar.gz"
+checksum = "sha256:90493b3bbd5e10f91d12153198bf1994fd756399b4fec93b49b0c6e2acdeeb3e"
+url = "https://dl.google.com/go/go1.27.0.darwin-arm64.tar.gz"
 
 [[tools."go:golang.org/x/vuln/cmd/govulncheck"]]
 version = "1.7.0"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-operations/yayamlls
 
-go 1.26.5
+go 1.27.0
 
 require (
 	github.com/goccy/go-yaml v1.19.2

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -2,6 +2,7 @@ package completion
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -101,8 +102,8 @@ func propertyCompletions(s *jsonschema.Schema, ic insertCtx) *protocol.Completio
 			Kind:          &kind,
 			Detail:        detail(ps),
 			Documentation: documentation(ps),
-			InsertText:    ptrStr(insert),
-			SortText:      ptrStr(sortKey(k, required[k])),
+			InsertText:    new(insert),
+			SortText:      new(sortKey(k, required[k])),
 		}
 		if isSnippet {
 			f := protocol.InsertTextFormatSnippet
@@ -149,12 +150,7 @@ func isType(s *jsonschema.Schema, t string) bool {
 	if s == nil || s.Types == nil {
 		return false
 	}
-	for _, st := range s.Types.ToStrings() {
-		if st == t {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.Types.ToStrings(), t)
 }
 
 // snippetEscape escapes the characters the LSP snippet grammar reserves.
@@ -180,7 +176,7 @@ func valueCompletions(s *jsonschema.Schema, ic insertCtx) *protocol.CompletionLi
 		if ic.needSpace {
 			// Right after "key:": insert " value" but keep the label bare so
 			// client-side filtering still matches what the user types.
-			item.InsertText = ptrStr(" " + item.Label)
+			item.InsertText = new(" " + item.Label)
 		}
 		items = append(items, item)
 	}
@@ -261,5 +257,3 @@ func sortKey(name string, required bool) string {
 	}
 	return "1" + name
 }
-
-func ptrStr(s string) *string { return &s }

--- a/internal/diagnostics/validate.go
+++ b/internal/diagnostics/validate.go
@@ -66,21 +66,20 @@ func validateDoc(doc *ast.DocumentNode, sch *jsonschema.Schema, src string, opts
 	value, err := yamlast.Decode(doc)
 	if err != nil {
 		return []protocol.Diagnostic{{
-			Severity: ptr(protocol.DiagnosticSeverityError),
-			Source:   ptr(Source),
+			Severity: new(protocol.DiagnosticSeverityError),
+			Source:   new(Source),
 			Message:  fmt.Sprintf("decode: %v", err),
 			Range:    yamlast.LocateRange(doc, "", src),
 		}}
 	}
 	value = normalizeMergeDirectives(value)
 	if err := sch.Validate(value); err != nil {
-		var verr *jsonschema.ValidationError
-		if errors.As(err, &verr) {
+		if verr, ok := errors.AsType[*jsonschema.ValidationError](err); ok {
 			return flattenValidationError(doc, verr, src, opts)
 		}
 		return []protocol.Diagnostic{{
-			Severity: ptr(protocol.DiagnosticSeverityError),
-			Source:   ptr(Source),
+			Severity: new(protocol.DiagnosticSeverityError),
+			Source:   new(Source),
 			Message:  err.Error(),
 			Range:    yamlast.LocateRange(doc, "", src),
 		}}
@@ -108,8 +107,8 @@ func flattenValidationError(
 			return protocol.Diagnostic{}, true
 		}
 		return protocol.Diagnostic{
-			Severity: ptr(protocol.DiagnosticSeverityError),
-			Source:   ptr(Source),
+			Severity: new(protocol.DiagnosticSeverityError),
+			Source:   new(Source),
 			Message:  fmt.Sprintf("%s (at %s)", Message(e), displayPointer(Pointer(e.InstanceLocation))),
 			Range:    leafRange(doc, e, src),
 			Data:     dataFor(e),
@@ -380,8 +379,8 @@ func displayPointer(p string) string {
 func parseErrorDiag(err error) protocol.Diagnostic {
 	rng, msg := parseErrorLocation(err.Error())
 	return protocol.Diagnostic{
-		Severity: ptr(protocol.DiagnosticSeverityError),
-		Source:   ptr(Source),
+		Severity: new(protocol.DiagnosticSeverityError),
+		Source:   new(Source),
 		Message:  msg,
 		Range:    rng,
 	}
@@ -412,12 +411,12 @@ func parseErrorLocation(s string) (protocol.Range, string) {
 }
 
 func splitLineCol(s string) (line, col int, ok bool) {
-	colon := strings.IndexByte(s, ':')
-	if colon < 0 {
+	before, after, ok := strings.Cut(s, ":")
+	if !ok {
 		return 0, 0, false
 	}
-	line, err1 := strconv.Atoi(s[:colon])
-	col, err2 := strconv.Atoi(s[colon+1:])
+	line, err1 := strconv.Atoi(before)
+	col, err2 := strconv.Atoi(after)
 	return line, col, err1 == nil && err2 == nil
 }
 
@@ -427,5 +426,3 @@ func oneBasedToZero(n int) uint32 {
 	}
 	return 0
 }
-
-func ptr[T any](v T) *T { return &v }

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -18,7 +18,7 @@ func Links(text string) []protocol.DocumentLink {
 			continue
 		}
 		rest := trimmed[len(modelinePrefix):]
-		for _, kv := range strings.Fields(rest) {
+		for kv := range strings.FieldsSeq(rest) {
 			k, v, ok := strings.Cut(kv, "=")
 			if !ok || strings.TrimSpace(k) != "$schema" {
 				continue

--- a/internal/lint/cli.go
+++ b/internal/lint/cli.go
@@ -157,7 +157,7 @@ func validateFile(
 					// defect: warn, don't fail CI. Schema violations of rendered
 					// manifests still come back as errors.
 					for i := range rendered {
-						rendered[i].Severity = ptr(protocol.DiagnosticSeverityWarning)
+						rendered[i].Severity = new(protocol.DiagnosticSeverityWarning)
 					}
 				}
 				diags = append(diags, rendered...)

--- a/internal/lint/rendered.go
+++ b/internal/lint/rendered.go
@@ -26,8 +26,8 @@ func RenderedDiagnostics(
 			return nil
 		}
 		return []protocol.Diagnostic{{
-			Severity: ptr(protocol.DiagnosticSeverityError),
-			Source:   ptr(renderSource(out)),
+			Severity: new(protocol.DiagnosticSeverityError),
+			Source:   new(renderSource(out)),
 			Message:  "render: " + err.Error(),
 			Range:    protocol.Range{},
 		}}
@@ -48,20 +48,19 @@ func RenderedDiagnostics(
 		value, err := yamlast.Decode(m.AST)
 		if err != nil {
 			diags = append(diags, protocol.Diagnostic{
-				Severity: ptr(protocol.DiagnosticSeverityWarning),
-				Source:   ptr(renderSource(out)),
+				Severity: new(protocol.DiagnosticSeverityWarning),
+				Source:   new(renderSource(out)),
 				Message:  fmt.Sprintf("[rendered %s/%s] decode failed: %v", m.GVK.Kind, m.Name, err),
 			})
 			continue
 		}
 		if err := sch.Validate(value); err != nil {
-			var verr *jsonschema.ValidationError
-			if errors.As(err, &verr) {
+			if verr, ok := errors.AsType[*jsonschema.ValidationError](err); ok {
 				diags = append(diags, flattenRendered(out, m, verr, opts)...)
 			} else {
 				diags = append(diags, protocol.Diagnostic{
-					Severity: ptr(protocol.DiagnosticSeverityError),
-					Source:   ptr(renderSource(out)),
+					Severity: new(protocol.DiagnosticSeverityError),
+					Source:   new(renderSource(out)),
 					Message:  fmt.Sprintf("[rendered %s/%s] %s", m.GVK.Kind, m.Name, err.Error()),
 				})
 			}
@@ -83,7 +82,7 @@ func flattenRendered(
 			loc = "/"
 		}
 		return protocol.Diagnostic{
-			Severity: ptr(protocol.DiagnosticSeverityError),
+			Severity: new(protocol.DiagnosticSeverityError),
 			Source:   &src,
 			Message:  fmt.Sprintf("[rendered %s/%s @ %s] %s", m.GVK.Kind, m.Name, loc, diagnostics.Message(e)),
 		}, false
@@ -96,5 +95,3 @@ func renderSource(out *render.RenderedOutput) string {
 	}
 	return diagnostics.Source + "/" + out.Provider
 }
-
-func ptr[T any](v T) *T { return &v }

--- a/internal/lsp/reload_test.go
+++ b/internal/lsp/reload_test.go
@@ -214,7 +214,7 @@ func TestConcurrent_NotifyAndClose(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		for i := 0; i < 200; i++ {
+		for range 200 {
 			s.Notify(uri, &render.RenderedOutput{Raw: []byte("v")}, nil)
 			_ = s.didClose(ctx, &protocol.DidCloseTextDocumentParams{
 				TextDocument: protocol.TextDocumentIdentifier{URI: uri},

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -150,7 +150,7 @@ func (s *Server) initialize(ctx *glsp.Context, params *protocol.InitializeParams
 	caps := s.handler.CreateServerCapabilities()
 	change := protocol.TextDocumentSyncKindIncremental
 	caps.TextDocumentSync = &protocol.TextDocumentSyncOptions{
-		OpenClose: ptr(true),
+		OpenClose: new(true),
 		Change:    &change,
 	}
 	caps.ExecuteCommandProvider = &protocol.ExecuteCommandOptions{
@@ -168,7 +168,7 @@ func (s *Server) initialize(ctx *glsp.Context, params *protocol.InitializeParams
 	// this capability, and clients withhold the notification until it's declared.
 	caps.Workspace = &protocol.ServerCapabilitiesWorkspace{
 		WorkspaceFolders: &protocol.WorkspaceFoldersServerCapabilities{
-			Supported:           ptr(true),
+			Supported:           new(true),
 			ChangeNotifications: &protocol.BoolOrString{Value: true},
 		},
 	}
@@ -394,8 +394,6 @@ func (s *Server) setTrace(ctx *glsp.Context, params *protocol.SetTraceParams) er
 func (s *Server) cancelRequest(ctx *glsp.Context, params *protocol.CancelParams) error {
 	return nil
 }
-
-func ptr[T any](v T) *T { return &v }
 
 // diagnosticOptions derives the validation options from the current
 // effective settings.

--- a/internal/lsp/showdocument.go
+++ b/internal/lsp/showdocument.go
@@ -52,7 +52,7 @@ func (s *Server) showInEditor(call glsp.CallFunc, uri, kind string) {
 	var res protocol.ShowDocumentResult
 	call(protocol.ServerWindowShowDocument, protocol.ShowDocumentParams{
 		URI:       fileuri.FromPath(path),
-		TakeFocus: ptr(true),
+		TakeFocus: new(true),
 	}, &res)
 }
 

--- a/internal/schema/glob.go
+++ b/internal/schema/glob.go
@@ -36,8 +36,7 @@ func globMatch(pat, s string) bool {
 		if pat == "" {
 			return s == ""
 		}
-		if strings.HasPrefix(pat, "**") {
-			rest := strings.TrimPrefix(pat, "**")
+		if rest, ok := strings.CutPrefix(pat, "**"); ok {
 			rest = strings.TrimPrefix(rest, "/")
 			if rest == "" {
 				return true

--- a/internal/schema/modeline.go
+++ b/internal/schema/modeline.go
@@ -65,7 +65,7 @@ func FindModelineSchema(text string) string {
 			continue
 		}
 		rest := strings.TrimSpace(strings.TrimPrefix(line, modelinePrefix))
-		for _, kv := range strings.Fields(rest) {
+		for kv := range strings.FieldsSeq(rest) {
 			k, v, ok := strings.Cut(kv, "=")
 			if !ok {
 				continue

--- a/internal/schema/resolver_test.go
+++ b/internal/schema/resolver_test.go
@@ -65,7 +65,7 @@ func TestMatchSettings_DeterministicMostSpecific(t *testing.T) {
 	if first != "./b.json" {
 		t.Fatalf("matchSettings = %q, want ./b.json (most specific)", first)
 	}
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		if got := matchSettings(schemas, docPath); got != first {
 			t.Fatalf("nondeterministic: call %d returned %q, want %q", i, got, first)
 		}

--- a/internal/schema/walk.go
+++ b/internal/schema/walk.go
@@ -18,7 +18,7 @@ func Resolve(root *jsonschema.Schema, ptr string) *jsonschema.Schema {
 	if ptr == "" || ptr == "/" {
 		return cur
 	}
-	for _, seg := range strings.Split(strings.TrimPrefix(ptr, "/"), "/") {
+	for seg := range strings.SplitSeq(strings.TrimPrefix(ptr, "/"), "/") {
 		next := step(cur, unescape(seg))
 		if next == nil {
 			return nil

--- a/internal/yamlast/locate.go
+++ b/internal/yamlast/locate.go
@@ -104,7 +104,7 @@ func lookup(doc *ast.DocumentNode, ptr string) (ast.Node, bool) {
 		return doc.Body, true
 	}
 	node := doc.Body
-	for _, raw := range strings.Split(strings.TrimPrefix(ptr, "/"), "/") {
+	for raw := range strings.SplitSeq(strings.TrimPrefix(ptr, "/"), "/") {
 		next, ok := descend(node, unescapePointerSegment(raw))
 		if !ok {
 			return nil, false
@@ -216,10 +216,7 @@ func tokenEnd(src string, t *token.Token) protocol.Position {
 // counts UTF-16 code units. src supplies the line so columns past a
 // non-BMP rune are translated correctly.
 func UTF16Position(src string, line, runeCol int) protocol.Position {
-	l := line - 1
-	if l < 0 {
-		l = 0
-	}
+	l := max(line-1, 0)
 	txt, _ := lineText(src, l)
 	return protocol.Position{Line: uint32(l), Character: utf16Column(txt, runeCol)}
 }


### PR DESCRIPTION
## Summary

- Pin `.mise/config.toml`'s `tools.go` to 1.27.0 (Dockerfile and the release workflow read it from there) and raise the `go.mod` directive to `1.27.0`.
- Apply the 1.27 modernizations `go fix` reports: `new(expr)` replaces the `ptr`/`ptrStr` helpers (removed once every caller was inlined), `errors.AsType`, `strings.SplitSeq`/`FieldsSeq`/`Cut`/`CutPrefix`, `slices.Contains`, range-over-int, and the `max` builtin.
- `go fix ./...` is a no-op on a second run, so the migration is idempotent.

## Verification

- `mise run test` (with `-race`), `mise run lint`, `go vet`, `gofmt -s -l`, `mise run build`: all pass.
- `mise run vulncheck`: 0 vulnerabilities (govulncheck v1.7.0 rebuilt under Go 1.27; a binary cached from the 1.26 toolchain fails with "application built with go1.26", so run `mise install --force 'go:golang.org/x/vuln/cmd/govulncheck@v1.7.0'` locally after pulling).