### PR TITLE
test(lsp): make the multi-doc test pass without network access

### DIFF
--- a/test/lsp_multidoc_test.go
+++ b/test/lsp_multidoc_test.go
@@ -17,11 +17,33 @@ func TestMultiDocMixedKinds(t *testing.T) {
 	bin := buildBinary(t)
 
 	root := t.TempDir()
-	// Pin yannh so the test doesn't depend on what the default mirror hosts.
-	cfg := `kubernetes:
-  schemaUrl: "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/{kind@L}-{groupFirst}{groupFirst:+-}{version}.json"
-catalog: false
-`
+	// Serve the kind schemas from disk so the test passes without network
+	// access (distro package builds run sandboxed). A fetch failure on an
+	// auto-detected kind yields zero diagnostics, which would look like a
+	// validation bug instead of a missing schema.
+	schemaDir := filepath.Join(root, "schemas")
+	if err := os.MkdirAll(schemaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	schemas := map[string]string{
+		"namespace.json": `{}`,
+		"service.json":   `{}`,
+		"deployment.json": `{
+  "type": "object",
+  "properties": {
+    "spec": {
+      "type": "object",
+      "properties": { "replicas": { "type": "integer" } }
+    }
+  }
+}`,
+	}
+	for name, body := range schemas {
+		if err := os.WriteFile(filepath.Join(schemaDir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := "kubernetes:\n  schemaUrl: \"file://" + schemaDir + "/{kind@L}.json\"\ncatalog: false\n"
 	if err := os.WriteFile(filepath.Join(root, ".yayamlls.yaml"), []byte(cfg), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/test/lsp_multidoc_test.go
+++ b/test/lsp_multidoc_test.go
@@ -25,14 +25,16 @@ func TestMultiDocMixedKinds(t *testing.T) {
 	if err := os.MkdirAll(schemaDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// Each schema pins its own kind so a document validated against a
+	// sibling's schema produces an extra diagnostic and fails the exact
+	// count below.
 	schemas := map[string]string{
-		"namespace.json": `{}`,
-		"service.json":   `{}`,
+		"namespace.json": `{"properties": {"kind": {"const": "Namespace"}}}`,
+		"service.json":   `{"properties": {"kind": {"const": "Service"}}}`,
 		"deployment.json": `{
-  "type": "object",
   "properties": {
+    "kind": { "const": "Deployment" },
     "spec": {
-      "type": "object",
       "properties": { "replicas": { "type": "integer" } }
     }
   }


### PR DESCRIPTION
Fixes #150

## Problem

`TestMultiDocMixedKinds` was the only integration test that fetched schemas from the public internet (`raw.githubusercontent.com/yannh/...`). In a sandboxed build with no network (the pkgsrc case in #150) the fetch fails, and since a failed fetch for an auto-detected Kubernetes schema is intentionally silent (`internal/lint/lint.go`), the server publishes zero diagnostics and the test reports `expected exactly 1 diagnostic ..., got 0: []`. This is not NetBSD-specific: the same failure reproduces on Linux by running the test inside `unshare -rn` with an empty `XDG_CACHE_HOME`.

## Change

Serve minimal per-kind schemas (`namespace.json`, `service.json`, `deployment.json` with `spec.replicas: integer`) from the test's temp workspace and point `kubernetes.schemaUrl` at them via a `file://.../{kind@L}.json` template, mirroring how `TestWorkspaceConfigFileFlowsThrough` already supplies a local schema. Namespace and Service get permissive `{}` schemas so the test still exercises independent per-document kind resolution rather than relying on two silent fetch failures. No non-test code changes.

## Verification

- `go test ./test -count=1` inside `unshare -rn` with a fresh `XDG_CACHE_HOME`: all 8 tests pass (previously `TestMultiDocMixedKinds` failed).
- Same run with network: passes.
- `mise run lint`: 0 issues.